### PR TITLE
Symlink service directories into $XDG_RUNTIME_DIR

### DIFF
--- a/pgctl/cli.py
+++ b/pgctl/cli.py
@@ -19,10 +19,12 @@ from py._path.local import LocalPath as Path
 from .config import Config
 from pgctl.service import Service
 
+
+XDG_RUNTIME_DIR = os.environ.get('XDG_RUNTIME_DIR') or '~/.run'
 PGCTL_DEFAULTS = frozendict({
     'pgdir': 'playground',
     'pgconf': 'conf.yaml',
-    'pghome': Path(os.environ.get('XDG_RUNTIME_DIR') or '~/.run', expanduser=True).join('pgctl').strpath,
+    'pghome': os.path.join(XDG_RUNTIME_DIR, 'pgctl'),
     'services': ('default',),
 })
 

--- a/pgctl/service.py
+++ b/pgctl/service.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import os
+from subprocess import check_call
+
+from cached_property import cached_property
+
+
+class Service(object):
+
+    def __init__(self, path, pgctl_app):
+        self.path = path
+        self._pgctl_app = pgctl_app
+
+    def __repr__(self):
+        return "Service('{path}')".format(path=self.path.strpath)
+
+    def __str__(self):
+        return self.name
+
+    def ensure_correct_directory_structure(self):
+        """Ensure that the services' directory structure is correct."""
+        self.ensure_scratch_dir_exists()
+        self.path.ensure('down')
+
+    def ensure_scratch_dir_exists(self):
+        """Ensure that the scratch directory exists and symlinks supervise.
+
+        Due to quirks in pip and potentially other package managers, we don't
+        want named FIFOs on disk inside the project repo (they'll end up in
+        tarballs and other junk).
+
+        Instead, we stick them in a scratch directory outside of the repo.
+        """
+        supervise_in_scratch = self.scratch_dir.join('supervise')
+        supervise_in_scratch.ensure_dir()
+
+        # ensure symlink {service_dir}/supervise -> {scratch_dir}/supervise
+        check_call((
+            'ln', '-sf', '--',
+            supervise_in_scratch.strpath,
+            self.path.join('supervise').strpath,
+        ))
+
+    @cached_property
+    def name(self):
+        return self.path.basename
+
+    @cached_property
+    def supervise_env(self):
+        """Returns an environment dict to use for running supervise."""
+        return dict(
+            os.environ,
+            PGCTL_SCRATCH=str(self.scratch_dir.strpath),
+        )
+
+    @cached_property
+    def scratch_dir(self):
+        """Return the scratch path for a service.
+
+        Scratch directories are located at
+           {pghome}/{absolute path of service}/
+        """
+        return self._pgctl_app.pghome.join(self.path.relto(str('/')))

--- a/pylintrc
+++ b/pylintrc
@@ -37,6 +37,9 @@ max-line-length=131
 [TYPECHECK]
 ignored-classes=pytest,LocalPath
 
+[SIMILARITIES]
+ignore-imports=yes
+
 [DESIGN]
 min-public-methods=0
 max-args=6

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,9 @@ TOP = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
 @fixture
-def in_example_dir(tmpdir, service_name):
-    os.environ['XDG_RUNTIME_DIR'] = tmpdir.join('.run').strpath
+def in_example_dir(tmpdir, homedir, service_name):
+    os.environ['HOME'] = homedir.strpath
+    os.environ.pop('XDG_RUNTIME_DIR', None)
 
     template_dir = os.path.join(TOP, 'tests/examples', service_name)
     tmpdir = tmpdir.join(service_name)
@@ -30,8 +31,13 @@ def scratch_dir(pghome_dir, service_name, in_example_dir):
 
 
 @fixture
-def pghome_dir(tmpdir):
-    yield tmpdir.join('.run', 'pgctl')
+def pghome_dir(homedir):
+    yield homedir.join('.run', 'pgctl')
+
+
+@fixture
+def homedir(tmpdir):
+    yield tmpdir.join('home')
 
 
 @fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 import os
 import shutil
 
+from py._path.local import LocalPath as Path
 from pytest import yield_fixture as fixture
 
 TOP = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -13,12 +14,24 @@ TOP = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 @fixture
 def in_example_dir(tmpdir, service_name):
+    os.environ['XDG_RUNTIME_DIR'] = tmpdir.join('.run').strpath
+
     template_dir = os.path.join(TOP, 'tests/examples', service_name)
     tmpdir = tmpdir.join(service_name)
     shutil.copytree(template_dir, tmpdir.strpath)
 
     with tmpdir.as_cwd():
         yield tmpdir
+
+
+@fixture
+def scratch_dir(pghome_dir, service_name, in_example_dir):
+    yield pghome_dir.join(Path().join('playground', service_name).relto(str('/')))
+
+
+@fixture
+def pghome_dir(tmpdir):
+    yield tmpdir.join('.run', 'pgctl')
 
 
 @fixture

--- a/tests/examples/date/playground/date/run
+++ b/tests/examples/date/playground/date/run
@@ -1,3 +1,2 @@
 #!/bin/bash
-cd ../..
-exec date > now.date
+exec date > $PGCTL_SCRATCH/now.date

--- a/tests/integration/cli.py
+++ b/tests/integration/cli.py
@@ -2,28 +2,40 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import os
 from subprocess import PIPE
 from subprocess import Popen
+
+import pytest
 
 
 class DescribeCli(object):
 
-    def it_can_show_its_configuration(self, tmpdir):
-        config1 = Popen(('pgctl-2015', 'config'), stdout=PIPE, cwd=tmpdir.strpath)
+    @pytest.mark.parametrize(
+        ('xdg_runtime_dir', 'expected_pghome'),
+        [
+            ('/herp/derp', '/herp/derp/pgctl'),
+            ('', '~/.run/pgctl'),
+        ],
+    )
+    def it_can_show_its_configuration(self, xdg_runtime_dir, expected_pghome, tmpdir):
+        env = dict(os.environ, XDG_RUNTIME_DIR=xdg_runtime_dir)
+        config1 = Popen(('pgctl-2015', 'config'), stdout=PIPE, cwd=tmpdir.strpath, env=env)
         config1, _ = config1.communicate()
         assert config1 == '''\
-{
+{{
     "command": "config", 
     "pgconf": "conf.yaml", 
     "pgdir": "playground", 
+    "pghome": "{pghome}",
     "services": [
         "default"
     ]
-}
-'''  # noqa
+}}
+'''.format(pghome=os.path.expanduser(expected_pghome))  # noqa
 
         from sys import executable
-        config2 = Popen((executable, '-m', 'pgctl.cli', 'config'), stdout=PIPE, cwd=tmpdir.strpath)
+        config2 = Popen((executable, '-m', 'pgctl.cli', 'config'), stdout=PIPE, cwd=tmpdir.strpath, env=env)
         config2, _ = config2.communicate()
         assert config1 == config2
 

--- a/tests/integration/cli.py
+++ b/tests/integration/cli.py
@@ -15,6 +15,7 @@ class DescribeCli(object):
         ('xdg_runtime_dir', 'expected_pghome'),
         [
             ('/herp/derp', '/herp/derp/pgctl'),
+            ('~/.herp', '~/.herp/pgctl'),
             ('', '~/.run/pgctl'),
         ],
     )
@@ -27,7 +28,7 @@ class DescribeCli(object):
     "command": "config", 
     "pgconf": "conf.yaml", 
     "pgdir": "playground", 
-    "pghome": "{pghome}",
+    "pghome": "{pghome}", 
     "services": [
         "default"
     ]

--- a/tests/integration/cli.py
+++ b/tests/integration/cli.py
@@ -19,7 +19,14 @@ class DescribeCli(object):
             ('', '~/.run/pgctl'),
         ],
     )
-    def it_can_show_its_configuration(self, xdg_runtime_dir, expected_pghome, tmpdir):
+    def it_can_show_its_configuration(
+            self,
+            xdg_runtime_dir,
+            expected_pghome,
+            tmpdir,
+            in_example_dir,
+            homedir,
+    ):
         env = dict(os.environ, XDG_RUNTIME_DIR=xdg_runtime_dir)
         config1 = Popen(('pgctl-2015', 'config'), stdout=PIPE, cwd=tmpdir.strpath, env=env)
         config1, _ = config1.communicate()
@@ -33,7 +40,7 @@ class DescribeCli(object):
         "default"
     ]
 }}
-'''.format(pghome=os.path.expanduser(expected_pghome))  # noqa
+'''.format(pghome=expected_pghome)  # noqa
 
         from sys import executable
         config2 = Popen((executable, '-m', 'pgctl.cli', 'config'), stdout=PIPE, cwd=tmpdir.strpath, env=env)

--- a/tests/integration/examples.py
+++ b/tests/integration/examples.py
@@ -23,11 +23,11 @@ class DescribeDateExample(object):
     def service_name(self):
         yield 'date'
 
-    def it_does_start(self, in_example_dir):
-        assert not os.path.isfile('now.date')
+    def it_does_start(self, in_example_dir, scratch_dir):
+        assert not scratch_dir.join('now.date').isfile()
         check_call(('pgctl-2015', 'start', 'date'))
         try:
-            assert os.path.isfile('now.date')
+            assert scratch_dir.join('now.date').isfile()
         finally:
             check_call(('pgctl-2015', 'stop', 'date'))
 
@@ -59,7 +59,7 @@ class DescribeStart(object):
         stdout, stderr = run(p)
         assert stdout == ''
         assert stderr == (
-            "Starting: ('unknown',)\n"
+            'Starting: unknown\n'
             "No such playground service: 'unknown'\n"
         )
         assert p.returncode == 1
@@ -88,7 +88,7 @@ class DescribeStop(object):
         stdout, stderr = run(p)
         assert stdout == ''
         assert stderr == (
-            "Stopping: ('unknown',)\n"
+            'Stopping: unknown\n'
             "No such playground service: 'unknown'\n"
         )
         assert p.returncode == 1
@@ -165,10 +165,10 @@ class DescribeRestart(object):
         p = Popen(('pgctl-2015', 'restart', 'date'), stdout=PIPE, stderr=PIPE)
         stdout, stderr = run(p)
         assert stderr == '''\
-Stopping: ('date',)
-Stopped: ('date',)
-Starting: ('date',)
-Started: ('date',)
+Stopping: date
+Stopped: date
+Starting: date
+Started: date
 '''
         assert stdout == ''
         assert p.returncode == 0

--- a/tests/unit/service.py
+++ b/tests/unit/service.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import mock
+from py._path.local import LocalPath as Path
+
+from pgctl.service import Service
+
+
+def test_str_and_repr():
+    service = Service(Path('/tmp/magic-service'), mock.Mock())
+
+    assert str(service) == 'magic-service'
+    assert repr(service) == "Service('/tmp/magic-service')"


### PR DESCRIPTION
This adds a new config option `pghome` which defaults to `$XDG_RUNTIME_DIR/pgctl` (where `XDG_RUNTIME_DIR` defaults to `~/.run` if not set).

The structure looks something like:
```
$ tree ~/.run
/nail/home/ckuehl/.run
└── pgctl
    └── nail
        └── home
            └── ckuehl
                └── proj
                    └── some_project
                        └── playground
                            ├── relode
                            │   └── supervise
                            │       ├── control
                            │       ├── lock
                            │       ├── ok
                            │       └── status
                            ├── uwsgi
                            │   └── supervise
                            │       ├── control
                            │       ├── lock
                            │       ├── ok
                            │       └── status
                            └── watch-templates
                                └── supervise
                                    ├── control
                                    ├── lock
                                    ├── ok
                                    └── status

13 directories, 12 files
```