### PR TITLE
Issue 38 bring down supervise

### DIFF
--- a/pgctl/cli.py
+++ b/pgctl/cli.py
@@ -19,6 +19,7 @@ from .daemontools import NoSuchService
 from .daemontools import svc
 from .daemontools import SvStat
 from .daemontools import svstat
+from .flock import Locked
 from .functions import exec_
 from .functions import JSONEncoder
 from .functions import uniq
@@ -81,6 +82,14 @@ class PgctlApp(object):
             # we don't need or want a stack trace for user errors
             return str(error)
 
+    def is_locked(self):
+        try:
+            for service in self.all_service_names:
+                self.service_by_name(service).check_lock()
+        except Locked:
+            time.sleep(.1)
+            return True
+
     def __change_state(self, opt, expected_state, xing, xed):
         """Changes the state of a supervised service using the svc command"""
         print(xing, self.service_names_string, file=stderr)
@@ -96,6 +105,13 @@ class PgctlApp(object):
                         break
                     else:
                         time.sleep(.01)
+                if opt == '-d':
+                    svc(('-dx',) + tuple(self.service_names))
+                    while self.is_locked():
+                        print('.', end='')
+                        import sys
+                        sys.stdout.flush()
+                    print('')
                 print(xed, self.service_names_string, file=stderr)
             except NoSuchService:
                 return "No such playground service: '%s'" % self.service_names_string
@@ -125,6 +141,7 @@ class PgctlApp(object):
     def restart(self):
         """Starts and stops a service"""
         self.stop()
+        self.app_invariants()
         self.start()
 
     def reload(self):

--- a/pgctl/service.py
+++ b/pgctl/service.py
@@ -66,6 +66,10 @@ class Service(namedtuple('Service', ['path', 'scratch_dir'])):
             # that it's already supervised: success
             return
 
+    def check_lock(self):
+        with flock(self.path.strpath):
+            pass
+
     @cached_property
     def name(self):
         return self.path.basename

--- a/tests/examples/environment/playground/environment/run
+++ b/tests/examples/environment/playground/environment/run
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+printenv MYVAR
+exec sleep infinity

--- a/tests/examples/output/playground/sweet/run
+++ b/tests/examples/output/playground/sweet/run
@@ -2,4 +2,4 @@
 echo sweet
 echo sweet_error >&2
 
-sleep infinity
+exec sleep infinity

--- a/tests/spec/examples.py
+++ b/tests/spec/examples.py
@@ -234,7 +234,7 @@ class DescribeStop(object):
         check_call(('pgctl-2015', 'start', 'date'))
         check_call(('pgctl-2015', 'stop', 'date'))
 
-        assert svstat('playground/date') == [C(SvStat, state='down')]
+        assert svstat('playground/date') == [C(SvStat, state='could not get status, supervisor is down')]
 
     def it_is_successful_before_start(self, in_example_dir):
         check_call(('pgctl-2015', 'stop', 'date'))
@@ -319,14 +319,13 @@ class DescribeRestart(object):
 
     def it_is_just_stop_then_start(self, in_example_dir):
         p = Popen(('pgctl-2015', 'restart', 'date'), stdout=PIPE, stderr=PIPE)
-        stdout, stderr = run(p)
+        _, stderr = run(p)
         assert stderr == '''\
 Stopping: date
 Stopped: date
 Starting: date
 Started: date
 '''
-        assert stdout == ''
         assert p.returncode == 0
         assert svstat('playground/date') == [C(SvStat, state='up')]
 
@@ -371,8 +370,8 @@ class DescribeStartMultipleServices(object):
             check_call(('pgctl-2015', 'stop', 'date', 'tail'))
 
             assert svstat('playground/date', 'playground/tail') == [
-                C(SvStat, state='down'),
-                C(SvStat, state='down'),
+                C(SvStat, state='could not get status, supervisor is down'),
+                C(SvStat, state='could not get status, supervisor is down'),
             ]
         finally:
             check_call(('pgctl-2015', 'stop', 'date', 'tail'))

--- a/tests/spec/examples.py
+++ b/tests/spec/examples.py
@@ -496,3 +496,37 @@ Started: ohhi, sweet
 Starting: ohhi, sweet
 Started: ohhi, sweet
 '''
+
+
+class DescribeEnvironment(object):
+
+    @fixture
+    def service_name(self):
+        yield 'environment'
+
+    def it_can_accept_different_environment_variables(self, in_example_dir):
+        check_call(('sh', '-c', 'MYVAR=ohhi pgctl-2015 start'))
+
+        p = Popen(('pgctl-2015', 'log'), stdout=PIPE, stderr=PIPE)
+        stdout, stderr = run(p)
+        assert p.returncode == 0
+        assert stderr == ''
+        assert stdout == '''\
+==> environment/stdout.log <==
+ohhi
+
+==> environment/stderr.log <==
+'''
+        check_call(('pgctl-2015', 'stop'))
+        check_call(('sh', '-c', 'MYVAR=bye pgctl-2015 start'))
+
+        p = Popen(('pgctl-2015', 'log'), stdout=PIPE, stderr=PIPE)
+        stdout, stderr = run(p)
+        assert p.returncode == 0
+        assert stderr == ''
+        assert stdout == '''\
+==> environment/stdout.log <==
+bye
+
+==> environment/stderr.log <==
+'''

--- a/tests/spec/examples.py
+++ b/tests/spec/examples.py
@@ -70,10 +70,8 @@ sweet_error
 
 ==> sweet/stdout.log <==
 sweet
-sweet
 
 ==> sweet/stderr.log <==
-sweet_error
 sweet_error
 '''
         assert p.returncode == 0
@@ -234,7 +232,7 @@ class DescribeStop(object):
         check_call(('pgctl-2015', 'start', 'date'))
         check_call(('pgctl-2015', 'stop', 'date'))
 
-        assert svstat('playground/date') == [C(SvStat, state='could not get status, supervisor is down')]
+        assert svstat('playground/date') == [C(SvStat, state=SvStat.UNSUPERVISED)]
 
     def it_is_successful_before_start(self, in_example_dir):
         check_call(('pgctl-2015', 'stop', 'date'))
@@ -370,8 +368,8 @@ class DescribeStartMultipleServices(object):
             check_call(('pgctl-2015', 'stop', 'date', 'tail'))
 
             assert svstat('playground/date', 'playground/tail') == [
-                C(SvStat, state='could not get status, supervisor is down'),
-                C(SvStat, state='could not get status, supervisor is down'),
+                C(SvStat, state=SvStat.UNSUPERVISED),
+                C(SvStat, state=SvStat.UNSUPERVISED),
             ]
         finally:
             check_call(('pgctl-2015', 'stop', 'date', 'tail'))


### PR DESCRIPTION
Multiple issues fixed in this branch to support ISSUE #38:
* Since we rely on ``svstat`` to determine if the process is down, I opted to call ``svc -d``, ``svstat`` check for ``down``, then ``svc -dx`` to kill the supervise process
* Killing the supervise process resulted in a deadlock due to race condition
  * Test Case: ``pgctl-2015 stop; pgctl-2015 start; pgctl-2015 stop; pgctl-2015 start; pgctl-2015 stop;``     
  * Race condition: after ``svc -dx`` it took a few seconds for the fd's to be released. Because the fd was not released in time the next time we try to start the process flock says the file is locked.  This has a compounding effect, the ``svc`` doesn't work because there is no supervise process and ``svstat`` results in ``supervise not running``, meaning we loop forever trying to start the service
  * Solution: is_locked
    * sweet_run did not ``exec`` sleep infinity, this meant that sleep processes were left around holding fd's and they deadlocked pgctl because of ``is_locked``
* ``pgctl-2015 status`` is flakey when running ``pgctl-2015 stop``.  ``stop`` unsupervises the service then ``status`` supervises the service.  ``svstat`` results in either ``supervise is not running``(because supervise is still starting) or ``service down for x seconds`` (because supervise is started)
* Added a test showing different environment variables being passed in to pgctl works