### PR TITLE
change debug to restart after debugging to allow pgctl to run stop before running start

### DIFF
--- a/pgctl/cli.py
+++ b/pgctl/cli.py
@@ -294,7 +294,7 @@ class PgctlApp(object):
             result = service.foreground()
         except KeyboardInterrupt:
             result = 1
-        self.start()
+        self.restart()
         return result
 
     def config(self):


### PR DESCRIPTION
If we don't do this and the process takes a long time to shutdown, pgctl start attempts to run before stop has finished and it fails to pgctl start.