### PR TITLE
Remove supervise for debug

### DIFF
--- a/pgctl/__init__.py
+++ b/pgctl/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 # NOTE: this file is imported by setup.py, so cannot have any dependencies or side-effect.
-__version__ = '1.6.1'
+__version__ = '1.6.2'

--- a/pgctl/service.py
+++ b/pgctl/service.py
@@ -198,9 +198,9 @@ class Service(namedtuple('Service', ['path', 'scratch_dir', 'default_timeout']))
     def foreground(self):
         with self.flock() as lock:
             exec_(
-                ('s6-supervise', self.path.strpath),
+                (str(self.path.join('run')),),
                 env=self.supervise_env(lock, debug=True),
-            )
+            )  # never returns
 
     @cached_property
     def name(self):


### PR DESCRIPTION
We don't need to supervise a process running in the foreground.