### PR TITLE
Add support for a playground-wide "pre-start" hook

### DIFF
--- a/pgctl/cli.py
+++ b/pgctl/cli.py
@@ -60,7 +60,7 @@ class StateChange(object):
         self.name = service.name
 
 
-class Start(StateChange):
+class start(StateChange):
 
     def change(self):
         return self.service.start()
@@ -77,7 +77,7 @@ class Start(StateChange):
         changed = 'Started:'
 
 
-class Stop(StateChange):
+class stop(StateChange):
 
     def change(self):
         return self.service.stop()
@@ -152,7 +152,7 @@ class PgctlApp(object):
     def __change_state(self, state):
         """Changes the state of a supervised service using the svc command"""
         # if we're starting a service, run the playground-wide "pre-start" hook (if it exists)
-        if state is Start:
+        if state is start:
             self.run_pre_start_hook()
 
         # we lock the whole playground; only one pgctl can change the state at a time, reliably
@@ -218,7 +218,10 @@ class PgctlApp(object):
         try:
             path = self.pgdir.join('pre-start')
             if path.exists():
-                subprocess.check_call((path.strpath))
+                subprocess.check_call(
+                    (path.strpath,),
+                    cwd=self.pgdir.dirname,
+                )
         except NoPlayground:
             # services can exist without a playground;
             # that's fine, but they can't have pre-start hooks
@@ -254,12 +257,12 @@ class PgctlApp(object):
 
     def start(self):
         """Idempotent start of a service or group of services"""
-        failed = self.__change_state(Start)
+        failed = self.__change_state(start)
         return self.__show_failure('start', failed)
 
     def stop(self):
         """Idempotent stop of a service or group of services"""
-        failed = self.__change_state(Stop)
+        failed = self.__change_state(stop)
         return self.__show_failure('stop', failed)
 
     def status(self):

--- a/pgctl/service.py
+++ b/pgctl/service.py
@@ -72,7 +72,7 @@ class Service(namedtuple('Service', ['path', 'scratch_dir', 'default_timeout']))
         return result
 
     def message(self, state):
-        script = self.path.join(state.__name__.lower() + '-msg')
+        script = self.path.join(state.__name__ + '-msg')
         if script.exists():
             check_call((script.strpath,))
 

--- a/pgctl/service.py
+++ b/pgctl/service.py
@@ -72,7 +72,7 @@ class Service(namedtuple('Service', ['path', 'scratch_dir', 'default_timeout']))
         return result
 
     def message(self, state):
-        script = self.path.join(state.__name__ + '-msg')
+        script = self.path.join(state.__name__.lower() + '-msg')
         if script.exists():
             check_call((script.strpath,))
 

--- a/tests/examples/pre-start-hook/playground/pre-start
+++ b/tests/examples/pre-start-hook/playground/pre-start
@@ -1,0 +1,2 @@
+#!/bin/bash -eu
+echo 'hello, i am a pre-start script' >&2

--- a/tests/examples/pre-start-hook/playground/pre-start
+++ b/tests/examples/pre-start-hook/playground/pre-start
@@ -1,2 +1,4 @@
 #!/bin/bash -eu
 echo 'hello, i am a pre-start script' >&2
+echo "--> \$PWD basename: $(basename "$PWD")" >&2
+echo "--> cwd basename: $(basename "$(pwd)")" >&2

--- a/tests/examples/pre-start-hook/playground/sweet/run
+++ b/tests/examples/pre-start-hook/playground/sweet/run
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo sweet
+echo sweet_error >&2
+
+exec sleep infinity

--- a/tests/spec/examples.py
+++ b/tests/spec/examples.py
@@ -654,6 +654,8 @@ class DescribePreStartHook(object):
             '',
             '''\
 hello, i am a pre-start script
+--> $PWD basename: pre-start-hook
+--> cwd basename: pre-start-hook
 [pgctl] Starting: sweet
 [pgctl] Started: sweet
 ''',

--- a/tests/spec/examples.py
+++ b/tests/spec/examples.py
@@ -639,3 +639,24 @@ Service has started at localhost:9001
 ''',
             0
         )
+
+
+class DescribePreStartHook(object):
+
+    @pytest.yield_fixture
+    def service_name(self):
+        yield 'pre-start-hook'
+
+    @pytest.mark.usefixtures('in_example_dir')
+    def it_runs_before_starting_a_service(self):
+        assert_command(
+            ('pgctl-2015', 'start'),
+            '',
+            '''\
+hello, i am a pre-start script
+[pgctl] Starting: sweet
+[pgctl] Started: sweet
+''',
+            0,
+            norm=norm.pgctl,
+        )


### PR DESCRIPTION
It is a very common requirement to want to require some build step before `pgctl` is invoked. For example, in a Python project, it would be great if we could force a run of venv-update (this should be very fast in the no-op case, and in the non-no-op case, you needed to run it anyway).

We currently hack this by running some make targets in services, but potentially all of the services could require these make targets, and we can't put it in all of them. Putting the make targets into the services also means we have to use unreasonable timeouts to account for non-no-op cases. These make regular development difficult.

With this change, you just throw your pre-start script at `playground/pre-start`.