### PR TITLE
Add post stop hook

### DIFF
--- a/pgctl/cli.py
+++ b/pgctl/cli.py
@@ -447,7 +447,7 @@ class PgctlApp(object):
         while stack:
             name = stack.pop()
             if name == ALL_SERVICES:
-                result.extend(self.all_service_names)
+                result.extend([str(service) for service in self.all_services])
             elif name in visited:
                 raise CircularAliases("Circular aliases! Visited twice during alias expansion: '%s'" % name)
             else:
@@ -460,18 +460,19 @@ class PgctlApp(object):
         return result
 
     @cached_property
-    def all_service_names(self):
-        """Return a tuple of all of the Services.
+    def all_services(self):
+        """Return a list of all services.
 
-        :return: tuple of strings -- the service names
+        :return: list of Service objects
+        :rtype: list
         """
         pgdir = self.pgdir.listdir(sort=True)
 
-        return tuple(
-            service_path.basename
+        return [
+            self.service_by_name(service_path.basename)
             for service_path in pgdir
             if service_path.check(dir=True)
-        )
+        ]
 
     @cached_property
     def service_names(self):

--- a/pgctl/cli.py
+++ b/pgctl/cli.py
@@ -233,11 +233,10 @@ class PgctlApp(object):
         with self.playground_locked():
             failures = self.__locked_change_state(state)
             if state is Stop:
-                for service in self.all_services:
-                    if service.state['state'] != 'down':
-                        break
-                else:
-                    run_post_stop_hook = True
+                run_post_stop_hook = all(
+                    service.state['state'] == 'down'
+                    for service in self.all_services
+                )
 
         # If the playground is in a fully stopped state, run the playground wide
         # post-stop hook. As with pre-start, this is done without holding a lock.

--- a/pgctl/service.py
+++ b/pgctl/service.py
@@ -71,6 +71,18 @@ class Service(namedtuple('Service', ['path', 'scratch_dir', 'default_timeout']))
         trace('PARSED: %s', result)
         return result
 
+    @property
+    def state(self):
+        svstat = self.svstat()
+        state = {
+            key: getattr(svstat, key)
+            for key in svstat._fields
+        }
+        if state['state'] == SvStat.UNSUPERVISED:
+            # this is the expected state for down services.
+            state['state'] = 'down'
+        return state
+
     def message(self, state):
         script = self.path.join(state.strings.change + '-msg')
         if script.exists():

--- a/tests/examples/post-stop-hook/playground/A/run
+++ b/tests/examples/post-stop-hook/playground/A/run
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo A
+echo A >&2
+
+exec sleep infinity

--- a/tests/examples/post-stop-hook/playground/B/run
+++ b/tests/examples/post-stop-hook/playground/B/run
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo B 
+echo B >&2
+
+exec sleep infinity

--- a/tests/examples/post-stop-hook/playground/post-stop
+++ b/tests/examples/post-stop-hook/playground/post-stop
@@ -1,0 +1,4 @@
+#!/bin/bash -eu
+echo 'hello, i am a post-stop script' >&2
+echo "--> \$PWD basename: $(basename "$PWD")" >&2
+echo "--> cwd basename: $(basename "$(pwd)")" >&2

--- a/tests/spec/examples.py
+++ b/tests/spec/examples.py
@@ -794,3 +794,68 @@ hello, i am a pre-start script
             0,
             norm=norm.pgctl,
         )
+
+
+class DescribePostStopHook(object):
+
+    @pytest.yield_fixture
+    def service_name(self):
+        yield 'post-stop-hook'
+
+    @pytest.mark.usefixtures('in_example_dir')
+    def it_runs_after_all_services_have_stopped(self):
+        assert_command(
+            ('pgctl', 'start', 'A'),
+            '',
+            '''\
+[pgctl] Starting: A
+[pgctl] Started: A
+''',
+            0,
+            norm=norm.pgctl,
+        )
+        assert_command(
+            ('pgctl', 'start', 'B'),
+            '',
+            '''\
+[pgctl] Starting: B
+[pgctl] Started: B
+''',
+            0,
+            norm=norm.pgctl,
+        )
+
+        assert_command(
+            ('pgctl', 'stop', 'A'),
+            '',
+            '''\
+[pgctl] Stopping: A
+[pgctl] Stopped: A
+''',
+            0,
+            norm=norm.pgctl,
+        )
+        assert_command(
+            ('pgctl', 'stop', 'B'),
+            '',
+            '''\
+[pgctl] Stopping: B
+[pgctl] Stopped: B
+hello, i am a post-stop script
+--> $PWD basename: post-stop-hook
+--> cwd basename: post-stop-hook
+''',
+            0,
+            norm=norm.pgctl,
+        )
+
+        # stopping when already down doesn't trigger post-stop to run again
+        assert_command(
+            ('pgctl', 'stop', 'A'),
+            '',
+            '''\
+[pgctl] Already stopped: A
+''',
+            0,
+            norm=norm.pgctl,
+        )

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -12,6 +12,7 @@ from pgctl.cli import _humanize_seconds
 from pgctl.cli import PgctlApp
 from pgctl.cli import TermStyle
 from pgctl.daemontools import SvStat
+from pgctl.service import Service
 
 
 @pytest.mark.parametrize(('seconds', 'expected'), [
@@ -41,9 +42,11 @@ def fake_statuses(statuses):
     app = PgctlApp()
     app.services = []
     for name, status in statuses:
-        m = mock.Mock(**{'svstat.return_value': status})
-        m.name = name
-        app.services.append(m)
+        service = Service('/dev/null', '/dev/null', 100)
+        service.svstat = mock.Mock(spec=service.svstat)
+        service.svstat.return_value = status
+        service.name = name
+        app.services.append(service)
     return app
 
 


### PR DESCRIPTION
pgctl provides a pre-start hook to run some user defined set up before launching playground services. If those user defined actions involve modifying some state, there isn't currently an easy way to clean up those modifications when the playground stops. This PR adds a hook that runs after all services in a playground have stopped.