### PR TITLE
Support post-start hook, invoked upon every successful "pgctl start"

### DIFF
--- a/pgctl/cli.py
+++ b/pgctl/cli.py
@@ -238,6 +238,11 @@ class PgctlApp(object):
                     for service in self.all_services
                 )
 
+            # Run the playground-wide "post-start" hook (if it exists) upon every `pgctl start'
+            if state is Start:
+                if all(service.state['state'] == 'ready' for service in self.services):
+                    self._run_playground_wide_hook('post-start')
+
         # If the playground is in a fully stopped state, run the playground wide
         # post-stop hook. As with pre-start, this is done without holding a lock.
         if run_post_stop_hook:

--- a/tests/examples/post-start-hook/playground/A/run
+++ b/tests/examples/post-start-hook/playground/A/run
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo A
+echo A >&2
+
+exec sleep infinity

--- a/tests/examples/post-start-hook/playground/B/run
+++ b/tests/examples/post-start-hook/playground/B/run
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo B 
+echo B >&2
+
+exec sleep infinity

--- a/tests/examples/post-start-hook/playground/post-start
+++ b/tests/examples/post-start-hook/playground/post-start
@@ -1,0 +1,4 @@
+#!/bin/bash -eu
+echo 'hello, i am a post-start script' >&2
+echo "--> \$PWD basename: $(basename "$PWD")" >&2
+echo "--> cwd basename: $(basename "$(pwd)")" >&2

--- a/tests/spec/examples.py
+++ b/tests/spec/examples.py
@@ -859,3 +859,51 @@ hello, i am a post-stop script
             0,
             norm=norm.pgctl,
         )
+
+
+class DescribePostStartHook(object):
+
+    @pytest.yield_fixture
+    def service_name(self):
+        yield 'post-start-hook'
+
+    @pytest.mark.usefixtures('in_example_dir')
+    def it_runs_after_every_single_pgctl_start(self):
+        assert_command(
+            ('pgctl', 'start', 'A'),
+            '',
+            '''\
+[pgctl] Starting: A
+[pgctl] Started: A
+hello, i am a post-start script
+--> $PWD basename: post-start-hook
+--> cwd basename: post-start-hook
+''',
+            0,
+            norm=norm.pgctl,
+        )
+
+        assert_command(
+            ('pgctl', 'start', 'B'),
+            '',
+            '''\
+[pgctl] Starting: B
+[pgctl] Started: B
+hello, i am a post-start script
+--> $PWD basename: post-start-hook
+--> cwd basename: post-start-hook
+''',
+            0,
+            norm=norm.pgctl,
+        )
+
+        # starting when already up doesn't trigger post-start to run again
+        assert_command(
+            ('pgctl', 'start'),
+            '',
+            '''\
+[pgctl] Already started: A, B
+''',
+            0,
+            norm=norm.pgctl,
+        )


### PR DESCRIPTION
A playground-wide post-start hook that is run once after a "pgctl start" call. This extends the existing "start-msg" so that coordinating type of scripts can be run after a group of services are up.