### PR TITLE
Fixed inaccurate sleep in poll_ready and other test issues.

### DIFF
--- a/tests/spec/unreliable.py
+++ b/tests/spec/unreliable.py
@@ -35,10 +35,10 @@ def it_fails_twice_but_doesnt_restart():
         '''\
 ==> playground/unreliable/log <==
 {TIMESTAMP} pgctl-poll-ready: service's ready check succeeded
-{TIMESTAMP} pgctl-poll-ready: failed (restarting in 2.00 seconds)
-{TIMESTAMP} pgctl-poll-ready: failed (restarting in 1.99 seconds)
+{TIMESTAMP} pgctl-poll-ready: failed (restarting in {TIME} seconds)
+{TIMESTAMP} pgctl-poll-ready: failed (restarting in {TIME} seconds)
 ''',
         '',
         0,
-        norm=norm.timestamp,
+        norm=norm.pgctl,
     )


### PR DESCRIPTION
The sleep in pgctl-poll-ready is not accurate and can cause some parts of the test suite to flake. This branch replaces the counting sleep loop with one that uses a time diff instead. It also fixes some hard coded time values in tests.