### PR TITLE
Replace xyz-msg with post-xyz hooks

### DIFF
--- a/pgctl/cli.py
+++ b/pgctl/cli.py
@@ -95,6 +95,9 @@ class Start(StateChange):
     def assert_(self):
         return self.service.assert_ready()
 
+    def changed(self):
+        return self.service.run_hook('post-start')
+
     def get_timeout(self):
         return self.service.timeout_ready
 
@@ -111,6 +114,9 @@ class Stop(StateChange):
 
     def assert_(self):
         return self.service.assert_stopped()
+
+    def changed(self):
+        return self.service.run_hook('post-stop')
 
     def get_timeout(self):
         return self.service.timeout_stop
@@ -269,6 +275,7 @@ class PgctlApp(object):
                     # TODO: debug() takes a lambda
                     debug('loop: check_time %.3f', now() - check_time)
                     pgctl_print(state.strings.changed, service.name)
+                    service.changed()
                     services.remove(service)
 
             time.sleep(float(self.pgconf['poll']))

--- a/pgctl/cli.py
+++ b/pgctl/cli.py
@@ -269,7 +269,6 @@ class PgctlApp(object):
                     # TODO: debug() takes a lambda
                     debug('loop: check_time %.3f', now() - check_time)
                     pgctl_print(state.strings.changed, service.name)
-                    service.service.message(state)
                     services.remove(service)
 
             time.sleep(float(self.pgconf['poll']))

--- a/pgctl/service.py
+++ b/pgctl/service.py
@@ -24,6 +24,7 @@ from .functions import bestrelpath
 from .functions import exec_
 from .functions import show_runaway_processes
 from .functions import symlink_if_necessary
+from .subprocess import check_call
 from .subprocess import Popen
 
 
@@ -99,6 +100,12 @@ class Service(namedtuple('Service', ['path', 'scratch_dir', 'default_timeout']))
         """Idempotent stop of a service or group of services"""
         self.ensure_exists()
         svc(('-dx', self.path.strpath))
+
+    def run_hook(self, hook_name):
+        """Runs the hook residing in the service path, if it exists."""
+        script = self.path.join(hook_name)
+        if script.exists():
+            check_call((script.strpath,))
 
     def __get_timeout(self, name, default):
         timeout = self.path.join(name, abs=1)

--- a/pgctl/service.py
+++ b/pgctl/service.py
@@ -24,7 +24,6 @@ from .functions import bestrelpath
 from .functions import exec_
 from .functions import show_runaway_processes
 from .functions import symlink_if_necessary
-from .subprocess import check_call
 from .subprocess import Popen
 
 
@@ -82,11 +81,6 @@ class Service(namedtuple('Service', ['path', 'scratch_dir', 'default_timeout']))
             # this is the expected state for down services.
             state['state'] = 'down'
         return state
-
-    def message(self, state):
-        script = self.path.join(state.strings.change + '-msg')
-        if script.exists():
-            check_call((script.strpath,))
 
     @cached_property
     def ready_script(self):

--- a/tests/examples/post-start-hook/playground/A/run
+++ b/tests/examples/post-start-hook/playground/A/run
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo A
+echo A >&2
+
+exec sleep infinity

--- a/tests/examples/post-start-hook/playground/B/run
+++ b/tests/examples/post-start-hook/playground/B/run
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo B 
+echo B >&2
+
+exec sleep infinity

--- a/tests/examples/post-start-hook/playground/post-start
+++ b/tests/examples/post-start-hook/playground/post-start
@@ -1,0 +1,4 @@
+#!/bin/bash -eu
+echo 'hello, i am a post-start script' >&2
+echo "--> \$PWD basename: $(basename "$PWD")" >&2
+echo "--> cwd basename: $(basename "$(pwd)")" >&2

--- a/tests/examples/post-start-service-hook/playground/A/post-start
+++ b/tests/examples/post-start-service-hook/playground/A/post-start
@@ -1,0 +1,4 @@
+#!/bin/bash -eu
+echo 'hello, i am a post-start script for A' >&2
+echo "--> \$PWD basename: $(basename "$PWD")" >&2
+echo "--> cwd basename: $(basename "$(pwd)")" >&2

--- a/tests/examples/post-start-service-hook/playground/A/run
+++ b/tests/examples/post-start-service-hook/playground/A/run
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo A
+echo A >&2
+
+exec sleep infinity

--- a/tests/examples/post-start-service-hook/playground/B/post-start
+++ b/tests/examples/post-start-service-hook/playground/B/post-start
@@ -1,0 +1,4 @@
+#!/bin/bash -eu
+echo 'hello, i am a post-start script for B' >&2
+echo "--> \$PWD basename: $(basename "$PWD")" >&2
+echo "--> cwd basename: $(basename "$(pwd)")" >&2

--- a/tests/examples/post-start-service-hook/playground/B/run
+++ b/tests/examples/post-start-service-hook/playground/B/run
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo B 
+echo B >&2
+
+exec sleep infinity

--- a/tests/examples/post-stop-service-hook/playground/A/post-stop
+++ b/tests/examples/post-stop-service-hook/playground/A/post-stop
@@ -1,0 +1,4 @@
+#!/bin/bash -eu
+echo 'hello, i am a post-stop script for A' >&2
+echo "--> \$PWD basename: $(basename "$PWD")" >&2
+echo "--> cwd basename: $(basename "$(pwd)")" >&2

--- a/tests/examples/post-stop-service-hook/playground/A/run
+++ b/tests/examples/post-stop-service-hook/playground/A/run
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo A
+echo A >&2
+
+exec sleep infinity

--- a/tests/examples/post-stop-service-hook/playground/B/post-stop
+++ b/tests/examples/post-stop-service-hook/playground/B/post-stop
@@ -1,0 +1,4 @@
+#!/bin/bash -eu
+echo 'hello, i am a post-stop script for B' >&2
+echo "--> \$PWD basename: $(basename "$PWD")" >&2
+echo "--> cwd basename: $(basename "$(pwd)")" >&2

--- a/tests/examples/post-stop-service-hook/playground/B/run
+++ b/tests/examples/post-stop-service-hook/playground/B/run
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo B 
+echo B >&2
+
+exec sleep infinity

--- a/tests/examples/start-message/playground/start-message/run
+++ b/tests/examples/start-message/playground/start-message/run
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-exec sleep infinity

--- a/tests/examples/start-message/playground/start-message/start-msg
+++ b/tests/examples/start-message/playground/start-message/start-msg
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-# Not actually, but to demonstrate
-echo "Service has started at localhost:9001" 1>& 2

--- a/tests/spec/examples.py
+++ b/tests/spec/examples.py
@@ -777,6 +777,50 @@ hello, i am a pre-start script
         )
 
 
+class DescribePostStartHook(object):
+
+    @pytest.yield_fixture
+    def service_name(self):
+        yield 'post-start-hook'
+
+    @pytest.mark.usefixtures('in_example_dir')
+    def it_runs_after_all_services_have_started(self):
+        assert_command(
+            ('pgctl', 'start', 'A'),
+            '',
+            '''\
+[pgctl] Starting: A
+[pgctl] Started: A
+''',
+            0,
+            norm=norm.pgctl,
+        )
+        assert_command(
+            ('pgctl', 'start', 'B'),
+            '',
+            '''\
+[pgctl] Starting: B
+[pgctl] Started: B
+hello, i am a post-start script
+--> $PWD basename: post-start-hook
+--> cwd basename: post-start-hook
+''',
+            0,
+            norm=norm.pgctl,
+        )
+
+        # starting when already ready doesn't trigger post-start to run again
+        assert_command(
+            ('pgctl', 'start'),
+            '',
+            '''\
+[pgctl] Already started: A, B
+''',
+            0,
+            norm=norm.pgctl,
+        )
+
+
 class DescribePostStopHook(object):
 
     @pytest.yield_fixture

--- a/tests/spec/examples.py
+++ b/tests/spec/examples.py
@@ -743,25 +743,6 @@ class DescribeDependentServices(object):
         )
 
 
-class DescribeStartMessageSuccess(object):
-
-    @pytest.yield_fixture
-    def service_name(self):
-        yield 'start-message'
-
-    def it_prints_a_start_message_on_successful_startup(self, in_example_dir):
-        assert_command(
-            ('pgctl', 'start', 'start-message'),
-            '',
-            '''\
-[pgctl] Starting: start-message
-[pgctl] Started: start-message
-Service has started at localhost:9001
-''',
-            0
-        )
-
-
 class DescribePreStartHook(object):
 
     @pytest.yield_fixture


### PR DESCRIPTION
1. xyz-msg's are killed. Instead, support service-scoped post-start and post-stop hooks.
2. Support post-start at playground level when ALL services are up. This is similar to the existing playground-wide post-stop hook.
3. Fix a bug when determining if the playground-wide post-stop hook should be run. When there is no playground, accessing `PgctlApp.all_services` would raise the NoPlayground exception. Hence I moved the conditioning into `_run_playground_wide_hook()` to leverage the `try-except` clause.
