### PR TITLE
Fixed race condition that left zombie poll readies.

### DIFF
--- a/pgctl/poll_ready.py
+++ b/pgctl/poll_ready.py
@@ -12,8 +12,8 @@ import os
 import os.path
 import select
 import time
+from sys import argv
 
-import pgctl.subprocess
 from .functions import exec_
 from .functions import print_stderr
 
@@ -103,12 +103,13 @@ def pgctl_poll_ready(down_fifo, notification_fd, timeout, poll_ready, poll_down,
 
 
 def main():
+    if os.environ.get('PGCTL_DEBUG'):
+        print_stderr('pgctl-poll-ready: disabled during debug -- quitting')
+        exec_(argv[1:])  # never returns
+
     # TODO-TEST: fail if notification-fd doesn't exist
     # TODO-TEST: echo 4 > notification-fd
     notification_fd = int(floatfile('notification-fd'))
-
-    # Make sure the notification fifodir exists
-    pgctl.subprocess.check_call(('s6-mkfifodir', 'event'))
 
     # Don't reuse an old FIFO
     try:
@@ -127,10 +128,7 @@ def main():
     if os.fork():  # parent
         os.close(down_fifo)  # we don't need this in the parent
         # run the wrapped command in the main process
-        from sys import argv
         exec_(argv[1:])  # never returns
-    elif os.environ.get('PGCTL_DEBUG'):
-        print_stderr('pgctl-poll-ready: disabled during debug -- quitting')
     else:  # child
         timeout = getval('timeout-ready', 'PGCTL_TIMEOUT', '2.0')
         poll_ready = getval('poll-ready', 'PGCTL_POLL', '0.15')

--- a/pgctl/poll_ready.py
+++ b/pgctl/poll_ready.py
@@ -13,6 +13,7 @@ import os.path
 import select
 import time
 
+import pgctl.subprocess
 from .functions import exec_
 from .functions import print_stderr
 
@@ -106,7 +107,25 @@ def main():
     # TODO-TEST: echo 4 > notification-fd
     notification_fd = int(floatfile('notification-fd'))
 
+    # Make sure the notification fifodir exists
+    pgctl.subprocess.check_call(('s6-mkfifodir', 'event'))
+
+    # Don't reuse an old FIFO
+    try:
+        os.remove(DOWN_FIFO_PATH)
+    except OSError:
+        # If it doesn't exist that's fine
+        pass
+
+    # Create a FIFO to listen for the s6 down event
+    #
+    # Even though the FIFO is effectively RO, it is opened as RW because
+    # opening as RO blocks until the other side of the FIFO is opened.
+    os.mkfifo(DOWN_FIFO_PATH)
+    down_fifo = os.open(DOWN_FIFO_PATH, os.O_RDWR)
+
     if os.fork():  # parent
+        os.close(down_fifo)  # we don't need this in the parent
         # run the wrapped command in the main process
         from sys import argv
         exec_(argv[1:])  # never returns
@@ -116,20 +135,6 @@ def main():
         timeout = getval('timeout-ready', 'PGCTL_TIMEOUT', '2.0')
         poll_ready = getval('poll-ready', 'PGCTL_POLL', '0.15')
         poll_down = getval('poll-down', 'PGCTL_POLL', '10.0')
-
-        try:
-            # Don't reuse an old FIFO
-            os.remove(DOWN_FIFO_PATH)
-        except OSError:
-            # If it doesn't exist that's fine
-            pass
-
-        # FIFO listens for the s6 down event
-        #
-        # Even though the FIFO is effectively RO, it is opened as RW because
-        # opening as RO blocks until the other side of the FIFO is opened.
-        os.mkfifo(DOWN_FIFO_PATH)
-        down_fifo = os.open(DOWN_FIFO_PATH, os.O_RDWR)
 
         try:
             pgctl_poll_ready(down_fifo, notification_fd, timeout, poll_ready, poll_down)

--- a/test
+++ b/test
@@ -39,7 +39,8 @@ if [ -z "$*" ]; then
     NCPU=$(getconf _NPROCESSORS_CONF)
     if "${CI:-false}"; then
         # Under CI, we don't get to use all the CPU.
-        NCPU=$((NCPU > 5? NCPU/5 : 1))
+        # To work around #176, parallelism is disabled in CI
+        NCPU=1
     fi
     n=$((NCPU > 5? NCPU/5 : 1))
     set -- -n $n $TOP/tests $($TOP/tests/testing/get_modulefile.py $PROJECT)

--- a/test
+++ b/test
@@ -39,10 +39,12 @@ if [ -z "$*" ]; then
     NCPU=$(getconf _NPROCESSORS_CONF)
     if "${CI:-false}"; then
         # Under CI, we don't get to use all the CPU.
-        # To work around #176, parallelism is disabled in CI
-        NCPU=1
+        # NOTE: Parallelism is disabled in CI because coverage flakes (#176)
+        n=0
+    else
+        n=$((NCPU > 5? NCPU/5 : 1))
     fi
-    n=$((NCPU > 5? NCPU/5 : 1))
+
     set -- -n $n $TOP/tests $($TOP/tests/testing/get_modulefile.py $PROJECT)
 
     # don't measure coverage during linting

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ project = pgctl
 envlist = py27,py35
 
 [testenv]
-passenv = PYTHONUSERBASE USER HOME EMAIL GIT_COMMITTER_NAME
+passenv = PYTHONUSERBASE USER HOME EMAIL GIT_COMMITTER_NAME CI
 deps = -rrequirements.d/test.txt
 changedir = {envtmpdir}
 commands = {posargs:{toxinidir}/test}


### PR DESCRIPTION
Fixes a race condition where the supervised service can start and die without a down notification being received by poll-ready. The details of the race are as follows (line # from original code):

1. Parent: L112 runs and S6 begins supervising the service
2. Parent: The service exits (nonzero code) and S6 sends the down notification
3. Child: L131 executes and the process subscribes to S6 notifications
4. The child never receives the down from step 2 because it wasn't listening soon enough.

A fix for that is to create the notification fifo prefork.

Note: after spending a bit of time trying to repro the race condition in a test, it seemed like that wasn't worth it (since the test would flake / false negative). Interactive testing with a known problem playground shows that this seems to have fixed the bug. 