### PR TITLE
pgctl debug and pre-start/post-stop fixes

### DIFF
--- a/pgctl/cli.py
+++ b/pgctl/cli.py
@@ -417,7 +417,11 @@ class PgctlApp(object):
 
         try:
             self._entering_debug = True
-            self.stop()
+            if service.state['state'] != 'down':
+                self.stop()
+            else:
+                # If we were not previously running, then also run pre-start
+                self._run_playground_wide_hook('pre-start')
             service.foreground()  # never returns
         finally:
             self._entering_debug = False

--- a/tests/examples/pre-start-hook/playground/pre-start
+++ b/tests/examples/pre-start-hook/playground/pre-start
@@ -1,4 +1,5 @@
 #!/bin/bash -eu
-echo 'hello, i am a pre-start script' >&2
+echo 'hello, i am a pre-start script in stdout'
+echo 'hello, i am a pre-start script in stderr' >&2
 echo "--> \$PWD basename: $(basename "$PWD")" >&2
 echo "--> cwd basename: $(basename "$(pwd)")" >&2

--- a/tests/spec/debug.py
+++ b/tests/spec/debug.py
@@ -80,7 +80,6 @@ def it_disables_polling():
 
     def check_file_contents():
         expected = '''\
-[pgctl] Already stopped: unreliable
 pgctl-poll-ready: disabled during debug -- quitting
 '''
         with open('stderr') as fd:

--- a/tests/spec/examples.py
+++ b/tests/spec/examples.py
@@ -798,36 +798,11 @@ hello, i am a pre-start script in stderr
         )
 
     @pytest.mark.usefixtures('in_example_dir')
-    def it_runs_before_debugging_a_stopped_service(self):
+    def it_runs_before_debugging_a_service(self):
         proc = Popen(('setsid', 'pgctl', 'debug', 'sweet'), stdin=PIPE, stdout=PIPE)
         proc.stdin.close()
         try:
             assert proc.stdout.readline() == 'hello, i am a pre-start script in stdout\n'
-        finally:
-            ctrl_c(proc)
-            proc.wait()
-
-    @pytest.mark.usefixtures('in_example_dir')
-    def it_doesnt_run_before_debugging_a_running_service(self):
-        assert_command(
-            ('pgctl', 'start'),
-            'hello, i am a pre-start script in stdout\n',
-            '''\
-hello, i am a pre-start script in stderr
---> $PWD basename: pre-start-hook
---> cwd basename: pre-start-hook
-[pgctl] Starting: sweet
-[pgctl] Started: sweet
-''',
-            0,
-            norm=norm.pgctl,
-        )
-
-        # debugging when already up doesn't trigger pre-start to run again
-        proc = Popen(('setsid', 'pgctl', 'debug', 'sweet'), stdin=PIPE, stdout=PIPE)
-        proc.stdin.close()
-        try:
-            assert proc.stdout.readline() == 'sweet\n'
         finally:
             ctrl_c(proc)
             proc.wait()
@@ -896,24 +871,3 @@ hello, i am a post-stop script
             0,
             norm=norm.pgctl,
         )
-
-    @pytest.mark.usefixtures('in_example_dir')
-    def it_doesnt_run_when_calling_debug(self):
-        assert_command(
-            ('pgctl', 'start', 'A'),
-            '',
-            '''\
-[pgctl] Starting: A
-[pgctl] Started: A
-''',
-            0,
-            norm=norm.pgctl,
-        )
-
-        proc = Popen(('setsid', 'pgctl', 'debug', 'A'), stdin=PIPE, stdout=PIPE)
-        proc.stdin.close()
-        try:
-            assert proc.stdout.readline() == 'A\n'
-        finally:
-            ctrl_c(proc)
-            proc.wait()


### PR DESCRIPTION
A couple fixes for interaction between pre-start/post-stop and pgctl debug:

1. Do not run post-stop if a service is being shut down to enter debug mode.
2. Run pre-start prior to entering debug mode on a stopped service.

Internal ticket COREBACK-1796