### PR TITLE
add allow-deleted option to fuser

### DIFF
--- a/pgctl/fuser.py
+++ b/pgctl/fuser.py
@@ -56,6 +56,10 @@ def fuser(path, allow_deleted=False):
             from os.path import join
             fd = join(fddir, fd)
             found = stat(fd)
+            if found is None:
+                # fd disappeared since we listed
+                continue
+
             if found == search:
                 yield pid
                 break
@@ -76,8 +80,6 @@ def main(args=None):
     parser.add_argument('-d', '--allow-deleted', action='store_true', help='allow deleted files')
     parser.add_argument('file', nargs='+')
     args = parser.parse_args(args[1:])
-    if not args.file:
-        parser.print_help()
 
     for f in args.file:
         for pid in fuser(f, allow_deleted=args.allow_deleted):

--- a/pgctl/fuser.py
+++ b/pgctl/fuser.py
@@ -11,22 +11,16 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from collections import namedtuple
-
 from .debug import trace
-
-StatTuple = namedtuple('StatTuple', ('st_ino', 'std_dev', 'st_nlink'))
 
 
 def stat(path):
     from os import stat
     try:
-        path = stat(path)
+        return stat(path)
     except EnvironmentError as error:
         trace('fuser suppressed: %s', error)
-        return None
-    else:
-        return StatTuple(path.st_ino, path.st_dev, path.st_nlink)
+    return None
 
 
 def listdir(path):


### PR DESCRIPTION
Tests are broken, first submitting this as an RFC. The scenario is to provide some way to cleanup playgrounds if the playground directory itself has been deleted, which is not too uncommon for automated builds.

A cleanup script would identify old playgrounds via `ycp list`. Non ycp users could do something with just pgrep s6-supervise and extracting the PGCTL_SERVICE environment variable.

Once you have the playground path, call `pgctl-fuser -d <playground_dir> | xargs kill -9`

Internal ticket COREBACK-2143