### PR TITLE
Fix incorrect hint messages about force stop

### DIFF
--- a/docs/source/user/quickstart.rst
+++ b/docs/source/user/quickstart.rst
@@ -73,7 +73,7 @@ becomes a problem:
                         USER        PID ACCESS COMMAND
     playground/sleeper:    buck     2847827 f.c.. sleep
 
-    To fix this temporarily, run: pgctl stop --force playground/sleeper
+    To fix this temporarily, run: pgctl stop playground/sleeper --force
     To fix it permanently, see:
         http://pgctl.readthedocs.org/en/latest/user/quickstart.html#writing-playground-services
 

--- a/pgctl/functions.py
+++ b/pgctl/functions.py
@@ -101,7 +101,7 @@ def show_runaway_processes(path):
 these runaway processes did not stop:
 %s
 There are two ways you can fix this:
-  * temporarily: pgctl stop --force %s
+  * temporarily: pgctl stop %s --force
   * permanently: http://pgctl.readthedocs.org/en/latest/user/quickstart.html#writing-playground-services
 ''' % (processes, bestrelpath(path))
         )

--- a/tests/spec/dirty_tests.py
+++ b/tests/spec/dirty_tests.py
@@ -118,7 +118,7 @@ class DescribeOrphanSubprocess(DirtyTest):
 {PS-STATS} sleep infinity
 
 There are two ways you can fix this:
-  * temporarily: pgctl stop --force playground/sweet
+  * temporarily: pgctl stop playground/sweet --force
   * permanently: http://pgctl.readthedocs.org/en/latest/user/quickstart.html#writing-playground-services
 
 ==> playground/sweet/logs/current <==
@@ -145,7 +145,7 @@ There are two ways you can fix this:
 {PS-STATS} sleep 987654
 
 There are two ways you can fix this:
-  * temporarily: pgctl stop --force playground/slow-startup
+  * temporarily: pgctl stop playground/slow-startup --force
   * permanently: http://pgctl.readthedocs.org/en/latest/user/quickstart.html#writing-playground-services
 
 ==> playground/slow-startup/logs/current <==
@@ -229,7 +229,7 @@ Learn why they did not stop: http://pgctl.readthedocs.org/en/latest/user/quickst
 {PS-STATS} sleep infinity
 
 There are two ways you can fix this:
-  * temporarily: pgctl stop --force playground/sweet
+  * temporarily: pgctl stop playground/sweet --force
   * permanently: http://pgctl.readthedocs.org/en/latest/user/quickstart.html#writing-playground-services
 
 ''',
@@ -345,7 +345,7 @@ class DescribeSlowShutdownOnBackground(DirtyTest):
 {PS-STATS} sleep 2.5
 
 There are two ways you can fix this:
-  * temporarily: pgctl stop --force playground/sweet
+  * temporarily: pgctl stop playground/sweet --force
   * permanently: http://pgctl.readthedocs.org/en/latest/user/quickstart.html#writing-playground-services
 
 ==> playground/sweet/logs/current <==


### PR DESCRIPTION
The hint message is incorrect --

> There are two ways you can fix this:
>   * temporarily: pgctl stop --force playground/sweet
>   * permanently: http://pgctl.readthedocs.org/en/latest/user/quickstart.html#writing-playground-services

"--force" is an optional argument while "stop" and "playground/sweet" are positional arguments; optional arguments cannot appear in between positional ones.  The pgctl command should instead be `pgctl --force stop playground/sweet` or `pgctl stop playground/sweet --force`.