### PR TITLE
Send a SIGKILL to s6-log instead of a SIGTERM (fixed #194).

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 -   repo: git://github.com/pre-commit/pre-commit-hooks
-    sha: adbb569fe9a64ad9bce3b53a77f1bc39ef31f682
+    sha: v0.9.1
     hooks:
     -   id: autopep8-wrapper
     -   id: check-added-large-files
@@ -17,7 +17,7 @@
     -   id: requirements-txt-fixer
     -   id: trailing-whitespace
 -   repo: git://github.com/asottile/reorder_python_imports
-    sha: 017e2f64306853ec7f000db52b8280da27eb3b96
+    sha: v0.3.5
     hooks:
     -   id: reorder-python-imports
         args:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -31,7 +31,7 @@ framework (although the tool happens to be written in Python).
 
 
 As a simple example, let's say that we want a `date` service in our playground,
-that ensures our `now.date` file always has the current date. 
+that ensures our `now.date` file always has the current date.
 
 ::
 
@@ -52,7 +52,7 @@ that ensures our `now.date` file always has the current date.
 
 Feature Support
 ---------------
-  
+
   -  User-friendly Command Line Interface
   -  Simple Configuration
   -  Python 2.7—3.5

--- a/docs/source/user/install.rst
+++ b/docs/source/user/install.rst
@@ -38,5 +38,3 @@ Once you have a copy of the source, you can embed it in your Python package,
 or install it into your site-packages easily::
 
     $ python setup.py install
-
-

--- a/docs/source/user/quickstart.rst
+++ b/docs/source/user/quickstart.rst
@@ -31,7 +31,7 @@ Once this is in place, you can start your playground and see it run.
   $ pgctl log
   [webapp] Serving HTTP on 0.0.0.0 port 36474 ...
 
-  $ curl 
+  $ curl
 
 
 .. _writing_services:

--- a/docs/source/user/usage.rst
+++ b/docs/source/user/usage.rst
@@ -52,7 +52,7 @@ status
     $ pgctl status <service=default>
     <service> (pid <PID>) -- up (0 seconds)
 
-Retrieves the state, PID, and time in that state of a specific service, group of services, or all services. 
+Retrieves the state, PID, and time in that state of a specific service, group of services, or all services.
 
 
 log

--- a/pgctl/service.py
+++ b/pgctl/service.py
@@ -128,7 +128,7 @@ class Service(namedtuple('Service', ['path', 'scratch_dir', 'default_timeout']))
 
     def stop_logs(self):
         self.ensure_logs()
-        svc(('-dx', self.path.join('.log').strpath))
+        svc(('-kx', self.path.join('.log').strpath))
 
     def force_cleanup(self):
         """Forcefully stop a service (i.e., `kill -9` all processes locking on `self.path.strpath`)"""
@@ -186,7 +186,7 @@ class Service(namedtuple('Service', ['path', 'scratch_dir', 'default_timeout']))
         with open(self.path.join('.log', 'run').strpath, 'w') as log_run:
             log_run.write(LOG_RUN_HEADER)
             log_run.write(
-                'exec s6-log n5 s10485760 T {log_path}\n'.format(
+                'exec s6-log -b n5 s10485760 T {log_path}\n'.format(
                     log_path=self.path.join('logs').strpath,
                 ),
             )

--- a/requirements.d/test.txt
+++ b/requirements.d/test.txt
@@ -5,7 +5,7 @@ coverage-enable-subprocess
 
 flake8
 mock
-pre-commit>=0.3.6
+pre-commit>=0.15.0
 pylint
 pytest
 pytest-env

--- a/tests/examples/post-stop-hook/playground/B/run
+++ b/tests/examples/post-stop-hook/playground/B/run
@@ -1,5 +1,5 @@
 #!/bin/bash
-echo B 
+echo B
 echo B >&2
 
 exec sleep infinity


### PR DESCRIPTION
Send a SIGKILL to s6-log instead of a SIGTERM. Also disable multiline buffering in s6-log to reduce the potential for log line loss that could occur due to SIGKILLing.