### PR TITLE
Fixed a test flake due to #195.

### DIFF
--- a/pgctl/cli.py
+++ b/pgctl/cli.py
@@ -152,7 +152,7 @@ class StopLogs(StateChange):
         raise NotImplementedError
 
     def get_timeout(self):
-        return self.service.timeout_ready
+        return self.service.timeout_stop
 
     is_user_facing = False
 

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -71,3 +71,13 @@ def test_status(statuses, expected):
         call[0][0] for call in mock_print.call_args_list
     )
     assert printed == expected
+
+
+def test_stop_logs_state():
+    """Because StopLogs executes a SIGKILL, the timeout can go unused in tests,
+    which causes coverage to miss the function. So we test it directly here.
+    """
+    class FakeService(object):
+        timeout_stop = 5
+        name = 'fake_service'
+    assert pgctl.cli.StopLogs(FakeService).get_timeout() == 5


### PR DESCRIPTION
Also use timeout_stop for a stop action instead of timeout_ready.