### PR TITLE
Fix build under python 3.6

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,7 @@
         - from __future__ import absolute_import
         - --add-import
         - from __future__ import unicode_literals
+    python_version: python3.6
 -   repo: https://github.com/asottile/pyupgrade
     sha: v1.0.4
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ venv:
 
 .PHONY: tests test
 test: install-hooks
-	tox -e py27 -- $(ARGS)
+	tox
 
 .PHONY: install-hooks
 install-hooks: venv

--- a/tests/spec/examples.py
+++ b/tests/spec/examples.py
@@ -823,7 +823,7 @@ hello, i am a pre-start script in stderr
         proc = Popen(('setsid', 'pgctl', 'debug', 'sweet'), stdin=PIPE, stdout=PIPE)
         proc.stdin.close()
         try:
-            assert proc.stdout.readline() == 'hello, i am a pre-start script in stdout\n'
+            assert proc.stdout.readline().decode('utf-8') == 'hello, i am a pre-start script in stdout\n'
         finally:
             ctrl_c(proc)
             proc.wait()

--- a/tests/testing/norm.py
+++ b/tests/testing/norm.py
@@ -32,7 +32,7 @@ class pgctl(Normalized):
     """normalize pgctl's output"""
     rules = timestamp.rules + (
         (Regex(r'\(pid \d+\)'), '(pid {PID})'),
-        (Regex(r'\pid: \d+'), 'pid: {PID}'),
+        (Regex(r'pid: \d+'), 'pid: {PID}'),
         (Regex(r' [\d.]+ seconds'), ' {TIME} seconds'),
         (
             Regex(r'(?m)^UID +PID +PPID +PGID +SID +C +STIME +TTY +STAT +TIME +CMD'),

--- a/tests/unit/functions.py
+++ b/tests/unit/functions.py
@@ -90,7 +90,7 @@ class DescribeShowRunawayProcesses(object):
 
 class DescribeTerminateRunawayProcesses(object):
 
-    def it_kills_processes_holding_the_lock(self, tmpdir):
+    def it_kills_processes_holding_the_lock(self, tmpdir, capsys):
         lockfile = tmpdir.ensure('lock')
         lock = lockfile.open()
 
@@ -104,18 +104,18 @@ class DescribeTerminateRunawayProcesses(object):
         # assert `process` has `lock`
         assert list(fuser(lockfile.strpath)) == [process.pid]
 
-        with mock.patch('sys.stderr', new_callable=six.StringIO) as mock_stderr:
-            terminate_runaway_processes(lockfile.strpath)
+        terminate_runaway_processes(lockfile.strpath)
 
-        assert 'WARNING: Killing these runaway ' in mock_stderr.getvalue()
+        _, stderr = capsys.readouterr()
+        assert 'WARNING: Killing these runaway ' in stderr
         wait_for(lambda: process.poll() == -9)
 
-    def it_passes_when_there_are_no_locks(self, tmpdir):
+    def it_passes_when_there_are_no_locks(self, tmpdir, capsys):
         lockfile = tmpdir.ensure('lock')
 
-        with mock.patch('sys.stderr', new_callable=six.StringIO) as mock_stderr:
-            terminate_runaway_processes(lockfile.strpath)
-        assert mock_stderr.getvalue() == ''
+        terminate_runaway_processes(lockfile.strpath)
+        _, stderr = capsys.readouterr()
+        assert stderr == ''
 
 
 class DescribePreexecFuncs(object):

--- a/tests/unit/functions.py
+++ b/tests/unit/functions.py
@@ -93,7 +93,12 @@ class DescribeTerminateRunawayProcesses(object):
     def it_kills_processes_holding_the_lock(self, tmpdir):
         lockfile = tmpdir.ensure('lock')
         lock = lockfile.open()
-        process = Popen(('sleep', 'infinity'))
+
+        # python 3.4+ closes file descriptors made by python unless explicitly
+        # passed and pass_fds isn't a parameter to Popen in python 2
+        extra_process_kwargs = {} if six.PY2 else dict(pass_fds=[lock.fileno()])
+        process = Popen(('sleep', 'infinity'), **extra_process_kwargs)
+
         lock.close()
 
         # assert `process` has `lock`

--- a/tests/unit/functions.py
+++ b/tests/unit/functions.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import os
-import StringIO
 
 import mock
 import pytest
@@ -60,8 +59,7 @@ class DescribeJSONEncoder(object):
 }'''
 
     def it_encodes_other(self):
-        msg = 'type' if six.PY2 else 'class'
-        with ShouldRaise(TypeError("<{} 'object'> is not JSON serializable".format(msg))):
+        with pytest.raises(TypeError):
             JSONEncoder(sort_keys=True, indent=4).encode(object)
 
 
@@ -101,7 +99,7 @@ class DescribeTerminateRunawayProcesses(object):
         # assert `process` has `lock`
         assert list(fuser(lockfile.strpath)) == [process.pid]
 
-        with mock.patch('sys.stderr', new_callable=StringIO.StringIO) as mock_stderr:
+        with mock.patch('sys.stderr', new_callable=six.StringIO) as mock_stderr:
             terminate_runaway_processes(lockfile.strpath)
 
         assert 'WARNING: Killing these runaway ' in mock_stderr.getvalue()
@@ -110,7 +108,7 @@ class DescribeTerminateRunawayProcesses(object):
     def it_passes_when_there_are_no_locks(self, tmpdir):
         lockfile = tmpdir.ensure('lock')
 
-        with mock.patch('sys.stderr', new_callable=StringIO.StringIO) as mock_stderr:
+        with mock.patch('sys.stderr', new_callable=six.StringIO) as mock_stderr:
             terminate_runaway_processes(lockfile.strpath)
         assert mock_stderr.getvalue() == ''
 


### PR DESCRIPTION
Most of this is straightforward and normal. Weirdest thing is that python 3.4+ changed behavior for file descriptors being passed to subprocesses.