### PR TITLE
Add basic telemetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,4 +9,9 @@ jobs:
         with:
           python-version: 3.7
       - run: pip install -r CI/install/requirements.txt
-      - run: tox
+      # s6 can't be built on newer versions of Ubuntu with the version of s6 on
+      # PyPI, and we can't get access to the s6 name on PyPI to fix it.
+      #
+      # For now we manually built and uploaded some wheels here just to
+      # get CI working. The wheel is built for Ubuntu 20.04.
+      - run: PIP_FIND_LINKS=https://yelp-travis-artifacts.s3.amazonaws.com/pgctl/index.html tox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Run Tests
 on: push
 jobs:
   tox:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/pgctl/telemetry.py
+++ b/pgctl/telemetry.py
@@ -1,0 +1,54 @@
+import datetime
+import getpass
+import json
+import os
+import socket
+import sys
+import typing
+
+import yaml
+
+from pgctl import __version__
+
+
+try:
+    import clog
+except ImportError:
+    clog = None
+
+_clog_configured = False
+
+
+def setup_clog(config_path: str) -> None:  # pragma: no cover
+    global _clog_configured
+    if clog is None or _clog_configured:
+        return
+
+    with open(config_path) as f:
+        clog_config = yaml.safe_load(f)
+    clog.config.configure_from_dict(clog_config)
+
+    _clog_configured = True
+
+
+def _event_context() -> typing.Dict[str, typing.Any]:
+    return {
+        'argv': sys.argv,
+        'cwd': os.getcwd(),
+        'hostname': socket.gethostname(),
+        'time': datetime.datetime.now().isoformat(),
+        'user': getpass.getuser(),
+        'version': __version__,
+    }
+
+
+def emit_event(event_name: str, attributes: typing.Dict[str, typing.Any]):
+    if not _clog_configured:
+        return
+
+    payload = dict(
+        _event_context(),
+        event=event_name,
+        attributes=attributes,
+    )
+    clog.log_line('tmp_pgctl_events', json.dumps(payload, sort_keys=True))

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,9 @@ def main():
             'pyyaml',
             's6',
         ],
+        extras_require={
+            'telemetry': ['yelp-clog'],
+        },
         # FIXME: all tests still pass if you break this.
         entry_points={
             'console_scripts': [

--- a/tests/spec/cli.py
+++ b/tests/spec/cli.py
@@ -42,6 +42,8 @@ class DescribeCli:
     "services": [
         "default"
     ],
+    "telemetry": false,
+    "telemetry_clog_config_path": null,
     "timeout": "2.0",
     "verbose": false
 }}

--- a/tests/spec/examples.py
+++ b/tests/spec/examples.py
@@ -651,6 +651,8 @@ class DescribePgdirMissing:
     "services": [
         "default"
     ],
+    "telemetry": false,
+    "telemetry_clog_config_path": null,
     "timeout": "2.0",
     "verbose": false
 }

--- a/tests/unit/telemetry_test.py
+++ b/tests/unit/telemetry_test.py
@@ -1,0 +1,38 @@
+import json
+from unittest import mock
+
+import pytest
+
+from pgctl import __version__
+from pgctl import telemetry
+
+
+@pytest.fixture
+def mock_clog():
+    with mock.patch.object(telemetry, '_clog_configured', True):
+        with mock.patch.object(telemetry, 'clog') as fake_clog:
+            yield fake_clog
+
+
+def test_event_context():
+    context = telemetry._event_context()
+    assert context['time'].startswith('20')
+    assert context['version'] == __version__
+
+
+def test_emit_event(mock_clog):
+    telemetry.emit_event('my_event', {'attr1': 'value1', 'attr2': 'value2'})
+    call, = mock_clog.mock_calls
+    _, args, _ = call
+
+    assert args[0] == 'tmp_pgctl_events'
+    payload = json.loads(args[1])
+    assert payload['attributes'] == {
+        'attr1': 'value1',
+        'attr2': 'value2',
+    }
+    assert payload['event'] == 'my_event'
+
+    # Just spot-checking some of the auto-injected context variables.
+    assert 'version' in payload
+    assert 'time' in payload


### PR DESCRIPTION
This adds some basic telemetry functionality to pgctl, backed by `yelp-clog` (scribe/monk). This is optional and disabled by default.

To enable it, one needs to have `yelp-clog` installed (e.g. by installing the new `pgctl[telemetry]` extra) and enable it explicitly in the pgctl config. This can be done by putting a file at `/etc/pgctl.json`, `~/.pgctl.json`, or `pgctl.json` in your working directory with contents like:

```json
{
    "telemetry": true,
    "telemetry_clog_config_path": "/etc/clog.yaml"
}
```

The motivation behind this is that we will soon be doing some improvements to try to make pgctl more resilient to poorly-behaving processes or unexpected user behavior, and we want to be able to measure if those changes are working. We will probably enable it by default on our boxes with `/etc/pgctl.json`.

It's tricky to add telemetry onto an open-source project like this because (a) open source users don't want it, and (b) it tends to rely on a semi-proprietary system for the reporting (clog here). I think this does an acceptable job though given the situation (nobody really uses pgctl outside of Yelp, and for the small number of people who do, these changes won't affect them).

Here are some example events:

#### `command_run`

```json
{
  "argv": [
    "/nail/home/ckuehl/proj/pgctl/pgctl/__main__.py",
    "--pgdir",
    "testing/playground",
    "log"
  ],
  "attributes": {
    "command": "log"
  },
  "cwd": "/nail/home/ckuehl/proj/pgctl",
  "event": "command_run",
  "hostname": "dev168-uswest1adevc",
  "time": "2021-10-13T12:38:53.223471",
  "user": "ckuehl",
  "version": "4.0.0"
}
```

#### `command_succeeded`

```json
{
  "argv": [
    "/nail/home/ckuehl/proj/pgctl/pgctl/__main__.py",
    "--pgdir",
    "testing/playground",
    "stop"
  ],
  "attributes": {
    "command": "stop",
    "elapsed_s": 0.2720189094543457,
    "result": null
  },
  "cwd": "/nail/home/ckuehl/proj/pgctl",
  "event": "command_succeeded",
  "hostname": "dev168-uswest1adevc",
  "time": "2021-10-13T12:36:15.764411",
  "user": "ckuehl",
  "version": "4.0.0"
}
```

#### `command_errored`

```json
{
  "argv": [
    "/nail/home/ckuehl/proj/pgctl/pgctl/__main__.py",
    "status"
  ],
  "attributes": {
    "command": "status",
    "elapsed_s": 0.22107839584350586,
    "result": "could not find any directory named 'playground'"
  },
  "cwd": "/nail/home/ckuehl/proj/pgctl",
  "event": "command_errored",
  "hostname": "dev168-uswest1adevc",
  "time": "2021-10-13T12:47:50.622286",
  "user": "ckuehl",
  "version": "4.0.0"
}
```