### PR TITLE
Require py>=1.4.32

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ def main():
             'frozendict',
             'cached-property',
             'contextlib2',
-            'py',
+            # 1.4.32 adds PathLike compatibility to py.path
+            'py>=1.4.32',
             'pyyaml',
             's6',
         ],


### PR DESCRIPTION
Old versions don't implement `__fspath__` on py.path objects and cause a crash like this:

```
$ pgctl stop
Traceback (most recent call last):
  File "/usr/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "xxx/virtualenv_run/lib/python3.7/site-packages/pgctl/__main__.py", line 4, in <module>
    exit(main())
  File "xxx/virtualenv_run/lib/python3.7/site-packages/pgctl/cli.py", line 738, in main
    return app()
  File "xxx/virtualenv_run/lib/python3.7/site-packages/pgctl/cli.py", line 222, in __call__
    result = command()
  File "xxx/virtualenv_run/lib/python3.7/site-packages/pgctl/cli.py", line 470, in stop
    failed = self.__change_state(Stop, self.services)
  File "xxx/virtualenv_run/lib/python3.7/site-packages/pgctl/cli.py", line 279, in __change_state
    state(service).assert_()
  File "xxx/virtualenv_run/lib/python3.7/site-packages/pgctl/cli.py", line 128, in assert_
    return self.service.assert_stopped(with_log_running=True)
  File "xxx/virtualenv_run/lib/python3.7/site-packages/pgctl/service.py", line 183, in assert_stopped
    escaped_running_pids = self.processes_currently_running()
  File "xxx/virtualenv_run/lib/python3.7/site-packages/pgctl/service.py", line 146, in processes_currently_running
    return self._pids_running_from_fuser() | self._pids_running_from_environment_tracing()
  File "xxx/virtualenv_run/lib/python3.7/site-packages/pgctl/service.py", line 132, in _pids_running_from_fuser
    return set(fuser.fuser(self.path)) - {os.getpid()}
  File "xxx/virtualenv_run/lib/python3.7/site-packages/pgctl/fuser.py", line 31, in fuser
    search = stat(path)
  File "xxx/virtualenv_run/lib/python3.7/site-packages/pgctl/fuser.py", line 14, in stat
    return stat(path)
TypeError: stat: path should be string, bytes, os.PathLike or integer, not LocalPath
```