### PR TITLE
Add an embedded log viewer during start/stop

### DIFF
--- a/pgctl/cli.py
+++ b/pgctl/cli.py
@@ -1,10 +1,13 @@
 import argparse
 import contextlib
+import enum
+import functools
 import json
 import os
 import subprocess
 import sys
 import time
+import typing
 from time import time as now
 
 import contextlib2
@@ -32,6 +35,7 @@ from .fuser import fuser
 from .service import Service
 from pgctl import __version__
 from pgctl import telemetry
+from pgctl.log_viewer import LogViewer
 
 
 XDG_RUNTIME_DIR = os.environ.get('XDG_RUNTIME_DIR') or '~/.run'
@@ -67,10 +71,15 @@ PGCTL_DEFAULTS = frozendict({
 CHANNEL = '[pgctl]'
 
 
-class StateChangeResult:
-    SUCCESS = 0
-    FAILURE = 1
-    RECHECK_NEEDED = 2
+class StateChangeOutcome(enum.Enum):
+    SUCCESS = enum.auto()
+    FAILURE = enum.auto()
+    RECHECK_NEEDED = enum.auto()
+
+
+class StateChangeResult(typing.NamedTuple):
+    outcome: StateChangeOutcome
+    output_message: typing.Optional[str]
 
 
 class TermStyle:
@@ -116,7 +125,7 @@ class Start(StateChange):
     class strings:
         change = 'start'
         changing = 'Starting:'
-        changed = 'Started:'
+        changed = 'started'
 
 
 class Stop(StateChange):
@@ -138,7 +147,7 @@ class Stop(StateChange):
     class strings:
         change = 'stop'
         changing = 'Stopping:'
-        changed = 'Stopped:'
+        changed = 'stopped'
 
 
 class StopLogs(StateChange):
@@ -159,7 +168,7 @@ class StopLogs(StateChange):
     class strings:
         change = 'stop'
         changing = 'Stopping logger for:'
-        changed = 'Stopped logger for:'
+        changed = 'stopped logger for'
 
 
 def unbuf_print(*args, **kwargs):
@@ -200,7 +209,7 @@ def error_message_on_timeout(service, error, action_name, actual_timeout_length,
             check_length,
         )  # TODO-TEST: pragma: no cover: we only hit this when lsof is being slow; add a unit test
     error_message += ', ' + str(error)
-    pgctl_print(error_message)
+    return '[pgctl] ' + error_message
 
 
 class PgctlApp:
@@ -282,8 +291,8 @@ class PgctlApp:
             else:
                 # Short-circuit, everything is in the correct state.
                 if self._should_display_state(state):
-                    pgctl_print('Already {} {}'.format(
-                        state.strings.changed.lower(),
+                    pgctl_print('Already {}: {}'.format(
+                        state.strings.changed,
                         commafy(_services_to_names(services))),
                     )
                 return []
@@ -311,40 +320,85 @@ class PgctlApp:
 
     def __locked_change_state(self, state, services):
         """the critical section of __change_state"""
+        log_viewer = None
         if self._should_display_state(state):
             pgctl_print(
                 state.strings.changing,
                 commafy(_services_to_names(services)),
             )
+            if sys.stdin.isatty():
+                log_viewer = LogViewer(20, {service.name: service.logfile_path for service in services})
 
-        services = [state(service) for service in services]
-        failed = []
-        start_time = now()
-        while services:
-            for service in services:
-                try:
-                    service.change()
-                except Unsupervised:
-                    pass  # handled in state assertion, below
-            for service in tuple(services):
-                state_change_result = self.__locked_handle_service_change_state(
-                    state,
-                    service,
-                    start_time,
-                )
+        try:
+            services = [state(service) for service in services]
+            failed = []
+            start_time = now()
+            while services:
+                for service in services:
+                    try:
+                        service.change()
+                    except Unsupervised:
+                        pass  # handled in state assertion, below
 
-                if state_change_result == StateChangeResult.RECHECK_NEEDED:
-                    # This service should be rechecked by the next iteration
-                    # of the outer loop
-                    continue
-                elif state_change_result == StateChangeResult.SUCCESS:
-                    services.remove(service)
+                changes_to_print = []
+
+                def print_service_change(service, state):
+                    pgctl_print(f'{state.strings.changed.title()}: {service.name}')
+
+                services_to_change = tuple(services)
+                for service in services_to_change:
+                    state_change_result = self.__locked_handle_service_change_state(
+                        state,
+                        service,
+                        start_time,
+                    )
+
+                    if state_change_result.outcome is StateChangeOutcome.RECHECK_NEEDED:
+                        # This service should be rechecked by the next iteration
+                        # of the outer loop
+                        pass
+                    elif state_change_result.outcome is StateChangeOutcome.SUCCESS:
+                        services.remove(service)
+                        if log_viewer is not None:
+                            log_viewer.stop_tailing(service.name)
+                        if self._should_display_state(state):
+                            changes_to_print.append(functools.partial(print_service_change, service, state))
+                            changes_to_print.append(functools.partial(service.service.message, state))
+                    else:
+                        # StateChangeOutcome.FAILURE
+                        failed.append(service.name)
+                        services.remove(service)
+                        if log_viewer is not None:
+                            log_viewer.stop_tailing(service.name)
+
+                    if state_change_result.output_message:
+                        changes_to_print.append(functools.partial(print, state_change_result.output_message, file=sys.stderr))
+
+                if log_viewer is not None:
+                    if len(changes_to_print) > 0 or log_viewer.redraw_needed():
+                        log_viewer.move_cursor_to_top()
+                        log_viewer.clear_below()
+
+                        for print_fn in changes_to_print:
+                            print_fn()
+
+                        log_viewer.draw_logs(
+                            'Still {} {}'.format(
+                                state.strings.changing.lower(),
+                                ', '.join(sorted(service.name for service in services)) or '<none>',
+                            ),
+                        )
+
+                    if not services:
+                        pgctl_print(f'All services have {state.strings.changed}')
                 else:
-                    # StateChangeResult.FAILURE
-                    failed.append(service.name)
-                    services.remove(service)
+                    for print_fn in changes_to_print:
+                        print_fn()
 
-            time.sleep(float(self.pgconf['poll']))
+                time.sleep(float(self.pgconf['poll']))
+        finally:
+            if log_viewer is not None:
+                log_viewer.cleanup()
 
         return failed
 
@@ -372,10 +426,7 @@ class PgctlApp:
         else:
             # TODO: debug() takes a lambda
             debug('loop: check_time %.3f', now() - check_time)
-            if self._should_display_state(state):
-                pgctl_print(state.strings.changed, service.name)
-            service.service.message(state)
-            return StateChangeResult.SUCCESS
+            return StateChangeResult(StateChangeOutcome.SUCCESS, None)
 
     def __locked_handle_state_change_exception(
         self,
@@ -384,7 +435,7 @@ class PgctlApp:
         error,
         start_time,
         check_time,
-    ):
+    ) -> StateChangeResult:
         """Handles a state change timeout for a service and returns whether
         the service unrecoverably failed its state change.
         """
@@ -392,22 +443,22 @@ class PgctlApp:
         if timeout(service, start_time, check_time, curr_time):
             if not self.pgconf['no_force']:
                 try:
-                    service.fail()
+                    return StateChangeResult(StateChangeOutcome.RECHECK_NEEDED, service.fail())
                 except NotImplementedError:
                     pass
-                else:
-                    return StateChangeResult.RECHECK_NEEDED
 
-            error_message_on_timeout(
-                service,
-                error,
-                state.strings.change,
-                actual_timeout_length=curr_time - start_time,
-                check_length=curr_time - check_time,
+            return StateChangeResult(
+                StateChangeOutcome.FAILURE,
+                error_message_on_timeout(
+                    service,
+                    error,
+                    state.strings.change,
+                    actual_timeout_length=curr_time - start_time,
+                    check_length=curr_time - check_time,
+                ),
             )
-            return StateChangeResult.FAILURE
 
-        return StateChangeResult.RECHECK_NEEDED
+        return StateChangeResult(StateChangeOutcome.RECHECK_NEEDED, None)
 
     def _should_display_state(self, state):
         return state.is_user_facing or self.pgconf['verbose']

--- a/pgctl/cli.py
+++ b/pgctl/cli.py
@@ -283,7 +283,10 @@ class PgctlApp:
 
     @property
     def log_viewer_enabled(self):
-        return self.pgconf['embedded_log_viewer'] and sys.stdin.isatty() and not os.environ.get('CI')
+        return (
+            self.pgconf.get('force_enable_log_viewer') == '1' or
+            (self.pgconf['embedded_log_viewer'] and sys.stdin.isatty() and not os.environ.get('CI'))
+        )
 
     def __change_state(self, state, services):
         """Changes the state of a supervised service using the svc command"""

--- a/pgctl/cli.py
+++ b/pgctl/cli.py
@@ -364,7 +364,7 @@ class PgctlApp:
                         if log_viewer is not None:
                             log_viewer.stop_tailing(service.name)
                         if self._should_display_state(state):
-                            changes_to_print.append(f'[pgctl] {state.strings.changed.title()}: {service.name}')
+                            changes_to_print.append(f'[pgctl] {state.strings.changed.capitalize()}: {service.name}')
                             state_change_message = (service.service.message(state) or '').strip()
                             if state_change_message:
                                 changes_to_print.append(state_change_message)
@@ -395,13 +395,16 @@ class PgctlApp:
                                 ', '.join(sorted(service.name for service in services)) or '<none>',
                             ),
                         )
-                        print(to_print, flush=True, end='')
+                        print(to_print, flush=True, end='', file=sys.stderr)
 
                     if not services:
                         pgctl_print(f'All services have {state.strings.changed}')
                 else:
                     for change in changes_to_print:
-                        print(change)
+                        # Need to flush here because otherwise the error
+                        # messages can get duplicated when __show_failure calls
+                        # fork().
+                        unbuf_print(change, file=sys.stderr)
 
                 time.sleep(float(self.pgconf['poll']))
         finally:

--- a/pgctl/cli.py
+++ b/pgctl/cli.py
@@ -392,12 +392,14 @@ class PgctlApp:
                         for change in changes_to_print:
                             to_print += change + '\n'
 
-                        to_print += log_viewer.draw_logs(
-                            'Still {} {}'.format(
-                                state.strings.changing.lower(),
-                                ', '.join(sorted(service.name for service in services)) or '<none>',
-                            ),
-                        )
+                        if services:
+                            to_print += log_viewer.draw_logs(
+                                'Still {} {}'.format(
+                                    state.strings.changing.lower(),
+                                    ', '.join(sorted(service.name for service in services)),
+                                ),
+                            )
+
                         print(to_print, flush=True, end='', file=sys.stderr)
 
                     if not services:

--- a/pgctl/functions.py
+++ b/pgctl/functions.py
@@ -3,6 +3,7 @@ import json
 import os
 import signal
 import sys
+import typing
 
 from frozendict import frozendict
 
@@ -102,23 +103,22 @@ Learn more: https://pgctl.readthedocs.org/en/latest/user/quickstart.html#writing
         )
 
 
-def terminate_processes(pids):
+def terminate_processes(pids) -> typing.Optional[str]:
     """forcefully kill processes"""
     processes = ps(pids)
     if processes:
-        print_stderr('''[pgctl] WARNING: Killing these runaway processes which did not stop:
-{}
-This usually means these processes are buggy.
-Learn more: https://pgctl.readthedocs.org/en/latest/user/quickstart.html#writing-playground-services
-'''.format(processes)
-        )
-
         for pid in pids:
             try:
                 os.kill(pid, signal.SIGKILL)
             except OSError:  # pragma: no cover
                 # race condition: processes stopped slightly after timeout, before we kill it
                 pass
+
+        return '''[pgctl] WARNING: Killing these runaway processes which did not stop:
+{}
+This usually means these processes are buggy.
+Learn more: https://pgctl.readthedocs.org/en/latest/user/quickstart.html#writing-playground-services
+'''.format(processes)
 
 
 def commafy(items):

--- a/pgctl/log_viewer.py
+++ b/pgctl/log_viewer.py
@@ -1,0 +1,161 @@
+import fcntl
+import os
+import re
+import select
+import shutil
+import subprocess
+import typing
+
+
+# https://stackoverflow.com/a/14693789
+# 7-bit C1 ANSI sequences
+ANSI_ESCAPES = re.compile(r'''
+    \x1B  # ESC
+    (?:   # 7-bit C1 Fe (except CSI)
+        [@-Z\\-_]
+    |     # or [ for CSI, followed by a control sequence
+        \[
+        [0-?]*  # Parameter bytes
+        [ -/]*  # Intermediate bytes
+        [@-~]   # Final byte
+    )
+''', re.VERBOSE)
+
+
+class TailEvent(typing.NamedTuple):
+    path: str
+    log_lines: typing.Tuple[str]
+
+
+class Tailer:
+
+    def __init__(self, paths: typing.Iterable[str]) -> None:
+        self._poll = select.poll()
+        self._path_to_tail = {}
+        self._fdno_to_path = {}
+
+        for path in paths:
+            self._path_to_tail[path] = proc = subprocess.Popen(
+                ('tail', '-F', path),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+            )
+            self._fdno_to_path[proc.stdout.fileno()] = path
+            self._poll.register(proc.stdout, select.POLLIN)
+
+            # Put stdout in non-blocking mode so we can read from it without blocking.
+            flags = fcntl.fcntl(proc.stdout.fileno(), fcntl.F_GETFL) | os.O_NONBLOCK
+            fcntl.fcntl(proc.stdout.fileno(), fcntl.F_SETFL, flags)
+
+    def get_logs(self, timeout: typing.Optional[float] = 0) -> typing.List[TailEvent]:
+        fd_events = self._poll.poll(timeout)
+        ret = []
+        for fd, event in fd_events:
+            content = b''
+            while True:
+                try:
+                    content += os.read(fd, 10000)
+                except BlockingIOError:
+                    break
+            ret.append(TailEvent(self._fdno_to_path[fd], content.splitlines()))
+        return ret
+
+    def new_lines_available(self) -> bool:
+        return len(self._poll.poll(0)) > 0
+
+    def stop_tailing(self, path: str) -> None:
+        proc = self._path_to_tail[path]
+        self._poll.unregister(proc.stdout)
+        del self._fdno_to_path[proc.stdout.fileno()]
+        del self._path_to_tail[path]
+        proc.terminate()
+        proc.communicate()
+
+    def cleanup(self) -> None:
+        for path in tuple(self._path_to_tail):
+            self.stop_tailing(path)
+
+
+def _draw_box(width: int, height: int, content_lines: typing.Sequence[str]):
+    inner_width = width - 2
+    inner_height = height - 2
+    assert inner_width >= 0, inner_width
+    assert inner_height >= 0, inner_height
+    assert len(content_lines) <= inner_height, (len(content_lines), inner_height)
+
+    # Disable screen wrap.
+    print('\x1b[?7l', end='')
+    # Hide the cursor.
+    print('\x1b[?25l', end='')
+
+    # Top border.
+    print('\x1b[1m╔' + '═' * inner_width + '╗\x1b[0K\x1b[0m')
+
+    # Inside box and log lines.
+    for i in range(inner_height):
+        try:
+            line = content_lines[i]
+        except IndexError:
+            line = ''
+        line = line[:inner_width].ljust(inner_width)
+        print('\x1b[1m║\x1b[0m' + line + f'\x1b[{width}G\x1b[1m║\x1b[0K\x1b[0m')
+
+    # Bottom border.
+    print('\x1b[1m╚' + '═' * inner_width + '╝\x1b[0K\x1b[0m')
+
+    # Re-enable screen wrap.
+    print('\x1b[?7h', end='')
+
+    # Show the cursor.
+    print('\x1b[?25h', end='', flush=True)
+
+
+class LogViewer:
+
+    def __init__(self, height: int, name_to_path: typing.Dict[str, str]):
+        self._tailer = Tailer(name_to_path.values())
+        self._prev_width = None
+        self._visible_lines = []
+        self._name_to_path = name_to_path
+        self._path_to_name = {path: name for name, path in name_to_path.items()}
+        self.height = height
+
+    def move_cursor_to_top(self) -> None:
+        if self._prev_width is not None:
+            # Move cursor back to the top of the box.
+            print(f'\x1b[{self.height + 2}F')
+
+    def _terminal_width(self) -> int:
+        return shutil.get_terminal_size((80, 20)).columns
+
+    def redraw_needed(self) -> bool:
+        return self._tailer.new_lines_available() or self._prev_width != self._terminal_width()
+
+    def clear_below(self) -> None:
+        print('\x1b[0J', end='', flush=True)
+
+    def draw_logs(self, title: str) -> None:
+        width = self._terminal_width()
+
+        log_events = self._tailer.get_logs(0)
+        for event in log_events:
+            for line in event.log_lines:
+                service = self._path_to_name[event.path]
+                line = ANSI_ESCAPES.sub('', line.decode('utf8', errors='replace'))
+                self._visible_lines.append(f'[{service}] {line}')
+        self._visible_lines = self._visible_lines[-(self.height - 2):]
+
+        # Disable screen wrap.
+        print('\x1b[?7l', end='')
+        print(title + '\x1b[0K')
+        # Re-enable screen wrap.
+        print('\x1b[?7h', end='')
+        _draw_box(width - 1, self.height, self._visible_lines)
+
+        self._prev_width = width
+
+    def stop_tailing(self, name: str) -> None:
+        self._tailer.stop_tailing(self._name_to_path[name])
+
+    def cleanup(self) -> None:
+        self._tailer.cleanup()

--- a/pgctl/service.py
+++ b/pgctl/service.py
@@ -145,9 +145,9 @@ class Service(namedtuple('Service', ['path', 'scratch_dir', 'default_timeout', '
     def processes_currently_running(self) -> typing.Set[int]:
         return self._pids_running_from_fuser() | self._pids_running_from_environment_tracing()
 
-    def force_cleanup(self):
-        """Forcefully stop a service (i.e., `kill -9` all processes locking on `self.path.strpath`)"""
-        terminate_processes(self.processes_currently_running())
+    def force_cleanup(self) -> typing.Optional[str]:
+        """Forcefully stop a service (i.e., `kill -9` all processes still running."""
+        return terminate_processes(self.processes_currently_running())
 
     def __get_timeout(self, name, default):
         timeout = self.path.join(name, abs=1)
@@ -224,6 +224,10 @@ Learn more: https://pgctl.readthedocs.org/en/latest/user/quickstart.html#writing
             os.fchmod(log_run.fileno(), log_run_stat.st_mode | stat.S_IXUSR)
 
         self._ensure_supervise_is_scratch('.log/supervise')
+
+    @property
+    def logfile_path(self):
+        return self.path.join('logs').join('current')
 
     def _ensure_supervise_is_scratch(self, supervise_rel_path):
         # ensure symlink {service_dir}/supervise_rel_path -> {scratch_dir}/supervise_rel_path

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,7 @@
 [flake8]
 max-line-length=131
 exclude=venv/,.tox,*.tmp,tmp/
-max-complexity=10
-ignore = E265,W504
+ignore = E265,W504,C901
 # E265 -- block comment should start with "# "
 
 [pep8]

--- a/tests/examples/slow-startup/playground/slow-startup/service
+++ b/tests/examples/slow-startup/playground/slow-startup/service
@@ -1,4 +1,6 @@
 #!/bin/bash
+echo 'waiting 2 seconds to become ready'
 sleep 2
+echo 'becoming ready now'
 touch readyfile
 exec sleep infinity

--- a/tests/spec/examples.py
+++ b/tests/spec/examples.py
@@ -270,7 +270,6 @@ class DescribeStartWithLogViewer:
         # testing for a few strings that should be present.
         assert '[pgctl] Starting: slow-startup\n' in output.err
         assert 'Still starting: slow-startup\n' in output.err
-        assert 'Still starting: <none>\n' in output.err
         assert '[pgctl] All services have started\n' in output.err
 
         # Make sure there's a log line that looks like:

--- a/tests/spec/examples.py
+++ b/tests/spec/examples.py
@@ -1,6 +1,7 @@
 import json
 import os
 import subprocess
+from unittest import mock
 
 import pytest
 from testing import norm
@@ -244,6 +245,39 @@ class DescribeStart:
 [pgctl] Started: sleep
 ''',
             0,
+        )
+
+
+class DescribeStartWithLogViewer:
+
+    @pytest.fixture
+    def service_name(self):
+        yield 'slow-startup'
+
+    def it_should_work_in_a_subdirectory(self, in_example_dir, capfd):
+        os.chdir(in_example_dir.join('playground').strpath)
+        with open(os.path.join('slow-startup', 'timeout-ready'), 'w') as f:
+            f.write('10\n')
+        with mock.patch.dict(
+            os.environ,
+            {'PGCTL_FORCE_ENABLE_LOG_VIEWER': '1'},
+        ):
+            subprocess.check_call(('pgctl', 'start', 'slow-startup'))
+
+        output = capfd.readouterr()
+
+        # Don't want to assert the entire embedded log viewer output, just
+        # testing for a few strings that should be present.
+        assert '[pgctl] Starting: slow-startup\n' in output.err
+        assert 'Still starting: slow-startup\n' in output.err
+        assert 'Still starting: <none>\n' in output.err
+        assert '[pgctl] All services have started\n' in output.err
+
+        # Make sure there's a log line that looks like:
+        # ║[slow-startup] 2021-11-02 10:39:51.406518500  waiting 2 seconds to become rea║
+        assert any(
+            '[slow-startup]' in line and 'waiting 2 seconds to become re' in line
+            for line in output.err.splitlines()
         )
 
 

--- a/tests/spec/slow_startup.py
+++ b/tests/spec/slow_startup.py
@@ -28,6 +28,7 @@ def assert_it_times_out_regardless_force(is_force):
 [pgctl] Starting: slow-startup
 [pgctl] ERROR: service 'slow-startup' failed to start after {TIME} seconds, its status is up (pid {PID}) {TIME} seconds
 ==> playground/slow-startup/logs/current <==
+{TIMESTAMP} waiting {TIME} seconds to become ready
 [pgctl] Stopping: slow-startup
 [pgctl] Stopped: slow-startup
 [pgctl]
@@ -44,6 +45,7 @@ def assert_it_times_out_regardless_force(is_force):
         ('pgctl', 'log'),
         '''\
 ==> playground/slow-startup/logs/current <==
+{TIMESTAMP} waiting {TIME} seconds to become ready
 {TIMESTAMP} pgctl-poll-ready: service is stopping -- quitting the poll
 ''',
         '',
@@ -114,12 +116,12 @@ def it_restarts_on_unready():
 {TIMESTAMP} pgctl-poll-ready: failed (restarting in {TIME} seconds)
 {TIMESTAMP} pgctl-poll-ready: failed (restarting in {TIME} seconds)
 {TIMESTAMP} pgctl-poll-ready: failed (restarting in {TIME} seconds)
-{TIMESTAMP} pgctl-poll-ready: failed (restarting in {TIME} seconds)
-{TIMESTAMP} pgctl-poll-ready: failed (restarting in {TIME} seconds)
 {TIMESTAMP} pgctl-poll-ready: failed for more than {TIME} seconds -- we are restarting this service for you
 {TIMESTAMP} [pgctl] Stopping: slow-startup
 {TIMESTAMP} [pgctl] Stopped: slow-startup
 {TIMESTAMP} [pgctl] Starting: slow-startup
+{TIMESTAMP} waiting {TIME} seconds to become ready
+{TIMESTAMP} becoming ready now
 {TIMESTAMP} pgctl-poll-ready: service's ready check succeeded
 {TIMESTAMP} [pgctl] Started: slow-startup
 ''',

--- a/tests/unit/functions.py
+++ b/tests/unit/functions.py
@@ -83,18 +83,15 @@ class DescribeShowRunawayProcesses:
 
 class DescribeTerminateProcesses:
 
-    def it_kills_processes(self, capsys):
+    def it_kills_processes(self):
         process = Popen(('sleep', 'infinity'))
-        terminate_processes({process.pid})
+        output = terminate_processes({process.pid})
 
-        _, stderr = capsys.readouterr()
-        assert 'WARNING: Killing these runaway ' in stderr
+        assert 'WARNING: Killing these runaway ' in output
         wait_for(lambda: process.poll() == -9)
 
-    def it_passes_when_there_are_no_pids_given(self, capsys):
-        terminate_processes(set())
-        _, stderr = capsys.readouterr()
-        assert stderr == ''
+    def it_passes_when_there_are_no_pids_given(self):
+        assert terminate_processes(set()) is None
 
 
 class DescribePreexecFuncs:

--- a/tests/unit/log_viewer_test.py
+++ b/tests/unit/log_viewer_test.py
@@ -1,0 +1,112 @@
+import os
+import shutil
+from unittest import mock
+
+import pytest
+from testing.assertions import wait_for
+
+from pgctl.log_viewer import LogViewer
+from pgctl.log_viewer import Tailer
+from pgctl.log_viewer import TailEvent
+
+
+def test_tailer(tmp_path):
+    file_a = (tmp_path / 'a').open('a+')
+    file_b = (tmp_path / 'b').open('a+')
+
+    # At the start there should be no lines.
+    tailer = Tailer((file_a.name, file_b.name))
+    assert tailer.new_lines_available() is False
+    assert tailer.get_logs() == []
+
+    # It should pick up changes to a single file.
+    file_a.write('A\n')
+    file_a.flush()
+    wait_for(lambda: tailer.new_lines_available() is True)
+    assert tailer.get_logs() == [TailEvent(file_a.name, [b'A'])]
+
+    assert tailer.new_lines_available() is False
+    assert tailer.get_logs() == []
+
+    # It should pick up changes to multiple files.
+    file_a.write('A\nA\n')
+    file_a.flush()
+    file_b.write('B\n')
+    file_b.flush()
+    wait_for(lambda: len(tailer._poll.poll()) == 2)
+    assert tailer.new_lines_available() is True
+    assert sorted(tailer.get_logs()) == [
+        TailEvent(file_a.name, [b'A', b'A']),
+        TailEvent(file_b.name, [b'B']),
+    ]
+
+    # It can stop tailing a file.
+    tailer.stop_tailing(file_a.name)
+    file_a.write('A\n')
+    file_a.flush()
+    file_b.write('B\n')
+    file_b.flush()
+    wait_for(lambda: tailer.new_lines_available() is True)
+    assert tailer.get_logs() == [TailEvent(file_b.name, [b'B'])]
+
+    tailer.cleanup()
+
+
+@pytest.fixture
+def mock_terminal_width():
+    fake_size = os.terminal_size((40, 40))
+    with mock.patch.object(shutil, 'get_terminal_size', autospec=True, return_value=fake_size):
+        yield
+
+
+@pytest.mark.usefixtures('mock_terminal_width')
+def test_log_viewer(tmp_path):
+    test_file = (tmp_path / 'test').open('a+')
+    log_viewer = LogViewer(10, {'test': test_file.name})
+    # A redraw is always needed at the start.
+    assert log_viewer.redraw_needed() is True
+    # Has not drawn so moving to top is a noop.
+    assert log_viewer.move_cursor_to_top() == ''
+
+    # It should initially draw an empty box.
+    assert log_viewer.draw_logs('My cool logs:') == (
+        '\x1b[?7lMy cool logs:\n'
+        '\x1b[?7h\x1b[?7l\x1b[?25l\x1b[1m╔═════════════════════════════════════╗\x1b[0K\x1b[0m\n'
+        '\x1b[1m║\x1b[0m                                     \x1b[39G\x1b[1m║\x1b[0K\x1b[0m\n'
+        '\x1b[1m║\x1b[0m                                     \x1b[39G\x1b[1m║\x1b[0K\x1b[0m\n'
+        '\x1b[1m║\x1b[0m                                     \x1b[39G\x1b[1m║\x1b[0K\x1b[0m\n'
+        '\x1b[1m║\x1b[0m                                     \x1b[39G\x1b[1m║\x1b[0K\x1b[0m\n'
+        '\x1b[1m║\x1b[0m                                     \x1b[39G\x1b[1m║\x1b[0K\x1b[0m\n'
+        '\x1b[1m║\x1b[0m                                     \x1b[39G\x1b[1m║\x1b[0K\x1b[0m\n'
+        '\x1b[1m║\x1b[0m                                     \x1b[39G\x1b[1m║\x1b[0K\x1b[0m\n'
+        '\x1b[1m║\x1b[0m                                     \x1b[39G\x1b[1m║\x1b[0K\x1b[0m\n'
+        '\x1b[1m╚═════════════════════════════════════╝\x1b[0K\x1b[0m\n'
+        '\x1b[?7h\x1b[?25h'
+    )
+    assert log_viewer.redraw_needed() is False
+
+    # It should pick up on log changes.
+    test_file.write(''.join(f'my cool log {i}\n' for i in range(30)))
+    test_file.flush()
+    wait_for(lambda: log_viewer.redraw_needed() is True)
+    assert log_viewer.move_cursor_to_top() == '\x1b[11F'
+    assert log_viewer.clear_below() == '\x1b[0J'
+
+    # It should now draw a box with the log lines.
+    assert log_viewer.draw_logs('My cool logs:') == (
+        '\x1b[?7lMy cool logs:\n'
+        '\x1b[?7h\x1b[?7l\x1b[?25l\x1b[1m╔═════════════════════════════════════╗\x1b[0K\x1b[0m\n'
+        '\x1b[1m║\x1b[0m[test] my cool log 22                \x1b[39G\x1b[1m║\x1b[0K\x1b[0m\n'
+        '\x1b[1m║\x1b[0m[test] my cool log 23                \x1b[39G\x1b[1m║\x1b[0K\x1b[0m\n'
+        '\x1b[1m║\x1b[0m[test] my cool log 24                \x1b[39G\x1b[1m║\x1b[0K\x1b[0m\n'
+        '\x1b[1m║\x1b[0m[test] my cool log 25                \x1b[39G\x1b[1m║\x1b[0K\x1b[0m\n'
+        '\x1b[1m║\x1b[0m[test] my cool log 26                \x1b[39G\x1b[1m║\x1b[0K\x1b[0m\n'
+        '\x1b[1m║\x1b[0m[test] my cool log 27                \x1b[39G\x1b[1m║\x1b[0K\x1b[0m\n'
+        '\x1b[1m║\x1b[0m[test] my cool log 28                \x1b[39G\x1b[1m║\x1b[0K\x1b[0m\n'
+        '\x1b[1m║\x1b[0m[test] my cool log 29                \x1b[39G\x1b[1m║\x1b[0K\x1b[0m\n'
+        '\x1b[1m╚═════════════════════════════════════╝\x1b[0K\x1b[0m\n'
+        '\x1b[?7h\x1b[?25h'
+    )
+    assert log_viewer.redraw_needed() is False
+
+    log_viewer.cleanup()


### PR DESCRIPTION
This adds an embedded log viewer during `pgctl start` and `pgctl stop` which tails the logs of the services being started or stopped. The idea is to help users understand what is going on when pgctl takes a long time to start or stop things.

It looks like this:

https://user-images.githubusercontent.com/665269/140195366-dc4e135f-7fee-4c21-a88e-5aa511fc8b7a.mov

There is some concern that all the new output may be confusing to users or make them think something is wrong. I tried to adjust the output a bit to improve this, but there is surely future room for improvement.

It is enabled by default but can be disabled via config option (per-project, per-user, or per-host), so we can turn it off if it causes problems.