### PR TITLE
Don't error when the terminal width is zero

### DIFF
--- a/pgctl/log_viewer.py
+++ b/pgctl/log_viewer.py
@@ -130,7 +130,13 @@ class LogViewer:
             return ''
 
     def _terminal_width(self) -> int:
-        return shutil.get_terminal_size((80, 20)).columns
+        columns = shutil.get_terminal_size((80, 20)).columns
+        if columns <= 5:
+            # This happens a lot with pty spawning (usually with 0x0 size).
+            # Just default to something reasonable.
+            return 80
+        else:
+            return columns
 
     def redraw_needed(self) -> bool:
         return self._tailer.new_lines_available() or self._prev_width != self._terminal_width()

--- a/tests/unit/log_viewer_test.py
+++ b/tests/unit/log_viewer_test.py
@@ -55,8 +55,22 @@ def test_tailer(tmp_path):
 @pytest.fixture
 def mock_terminal_width():
     fake_size = os.terminal_size((40, 40))
-    with mock.patch.object(shutil, 'get_terminal_size', autospec=True, return_value=fake_size):
-        yield
+    with mock.patch.object(shutil, 'get_terminal_size', autospec=True, return_value=fake_size) as m:
+        yield m
+
+
+@pytest.mark.parametrize(
+    ('size', 'expected_width'),
+    (
+        (os.terminal_size((40, 20)), 40),
+        (os.terminal_size((0, 0)), 80),
+        (os.terminal_size((-1, -1)), 80),
+    ),
+)
+def test_log_viewer_terminal_width(size, expected_width, mock_terminal_width):
+    mock_terminal_width.return_value = size
+    log_viewer = LogViewer(10, {})
+    assert log_viewer._terminal_width() == expected_width
 
 
 @pytest.mark.usefixtures('mock_terminal_width')


### PR DESCRIPTION
We were already providing a fallback terminal width, but it turns out that it's still possible to get a zero terminal width without it producing an actual error.

Internal ticket: CORESERV-11279