### PR TITLE
Force kill any unsupervised processes at the start

### DIFF
--- a/pgctl/functions.py
+++ b/pgctl/functions.py
@@ -103,7 +103,7 @@ Learn more: https://pgctl.readthedocs.org/en/latest/user/quickstart.html#writing
         )
 
 
-def terminate_processes(pids) -> typing.Optional[str]:
+def terminate_processes(pids: typing.Iterable[int], is_stop: bool = True) -> typing.Optional[str]:
     """forcefully kill processes"""
     processes = ps(pids)
     if processes:
@@ -114,10 +114,17 @@ def terminate_processes(pids) -> typing.Optional[str]:
                 # race condition: processes stopped slightly after timeout, before we kill it
                 pass
 
-        return '''[pgctl] WARNING: Killing these runaway processes which did not stop:
+        if is_stop:
+            return '''WARNING: Killing these runaway processes which did not stop:
 {}
 This usually means these processes are buggy.
 Learn more: https://pgctl.readthedocs.org/en/latest/user/quickstart.html#writing-playground-services
+'''.format(processes)
+        else:
+            return '''WARNING: Killing these processes which were still running but escaped supervision:
+{}
+This usually means that s6-supervise was not stopped cleanly (e.g. manually killed).
+Learn more: https://pgctl.readthedocs.io/en/latest/user/usage.html#stop
 '''.format(processes)
 
 

--- a/pgctl/service.py
+++ b/pgctl/service.py
@@ -149,9 +149,9 @@ class Service(namedtuple('Service', ['path', 'scratch_dir', 'default_timeout', '
     def processes_currently_running(self) -> typing.Set[int]:
         return self._pids_running_from_fuser() | self._pids_running_from_environment_tracing()
 
-    def force_cleanup(self) -> typing.Optional[str]:
+    def force_cleanup(self, is_stop: bool = True) -> typing.Optional[str]:
         """Forcefully stop a service (i.e., `kill -9` all processes still running."""
-        return terminate_processes(self.processes_currently_running())
+        return terminate_processes(self.processes_currently_running(), is_stop=is_stop)
 
     def __get_timeout(self, name, default):
         timeout = self.path.join(name, abs=1)


### PR DESCRIPTION
Currently `pgctl start` will crash with a confusing error message if there are any processes holding the s6 lock (but no `s6-supervise` command running). This is happening a few times per day according to our telemetry and we sometimes get reports about the hard-to-understand and hard-to-fix error.

After this change, any unsupervised processes (detected via both s6 lock file and environment variable tracing) will be terminated if the service is unsupervised. This will reduce errors from pgctl _and_ confusing errors in cases where the orphaned process is holding a resource (like a port) that causes the new process to crash loop.