### PR TITLE
Service dependency ordering for `pgctl start`

### DIFF
--- a/docs/source/user/advanced.rst
+++ b/docs/source/user/advanced.rst
@@ -5,6 +5,35 @@ Advanced Usage
 
 You may (or may not) want these notes after using pgctl for a while.
 
+
+Service Dependencies
+--------------------
+
+When services depend on each other, you can declare a startup ordering in ``pgctl.yaml`` so that dependencies are ready before their dependents start. On stop, the order is reversed — dependents stop before their dependencies.
+
+.. code-block:: yaml
+
+    dependencies:
+        api:
+            - db
+            - cache
+        web:
+            - api
+
+In this example, ``pgctl start`` will:
+
+1. Start ``db`` and ``cache`` (in parallel, since they have no mutual dependency)
+2. Wait until both are ready
+3. Start ``api``
+4. Wait until ``api`` is ready
+5. Start ``web``
+
+``pgctl stop`` reverses the order: ``web`` stops first, then ``api``, then ``db`` and ``cache``.
+
+If a dependency fails to start, pgctl will not attempt to start services that depend on it.
+
+Circular dependencies (e.g. A depends on B, B depends on A) are detected and reported as an error.
+
 Services that stop slowly
 -------------------------
 

--- a/pgctl/cli.py
+++ b/pgctl/cli.py
@@ -19,7 +19,6 @@ from .configsearch import search_parent_directories
 from .debug import debug
 from .debug import trace
 from .dependencies import resolve_start_order
-from .dependencies import resolve_stop_order
 from .errors import CircularAliases
 from .errors import LockHeld
 from .errors import NoPlayground
@@ -541,19 +540,14 @@ class PgctlApp:
         deps = self.pgconf.get('dependencies', {})
         return {k: tuple(v) if isinstance(v, list) else (v,) for k, v in deps.items()}
 
-    def _services_in_start_order(self):
-        return resolve_start_order(self.services, self.dependency_map)
-
-    def _services_in_stop_order(self):
-        return resolve_stop_order(self.services, self.dependency_map)
-
-    def _group_by_dependency_phase(self, ordered_services, reverse=False):
+    def _group_by_dependency_phase(self, ordered_services):
         """Group services into phases where each phase's services have all
         dependencies satisfied by prior phases.
 
         Returns a list of lists of services.
         """
         dep_map = self.dependency_map
+        service_names_in_scope = {s.name for s in ordered_services}
         started = set()
         phases = []
         remaining = list(ordered_services)
@@ -562,7 +556,6 @@ class PgctlApp:
             phase = []
             for service in list(remaining):
                 deps = set(dep_map.get(service.name, ()))
-                service_names_in_scope = {s.name for s in self.services}
                 relevant_deps = deps & service_names_in_scope
                 if relevant_deps <= started:
                     phase.append(service)
@@ -579,7 +572,9 @@ class PgctlApp:
         """Idempotent start of a service or group of services"""
         dep_map = self.dependency_map
         if dep_map:
-            ordered = self._services_in_start_order()
+            ordered = resolve_start_order(
+                self.services, dep_map, self.service_by_name,
+            )
             phases = self._group_by_dependency_phase(ordered)
             all_failed = []
             for phase in phases:
@@ -600,17 +595,7 @@ class PgctlApp:
         want to leave the logger running (since poll-ready may still be writing
         log messages).
         """
-        dep_map = self.dependency_map
-        if dep_map:
-            ordered = self._services_in_stop_order()
-            phases = self._group_by_dependency_phase(ordered, reverse=True)
-            all_failed = []
-            for phase in phases:
-                phase_failed = self.__change_state(Stop, phase)
-                all_failed.extend(phase_failed)
-            failed = all_failed
-        else:
-            failed = self.__change_state(Stop, self.services)
+        failed = self.__change_state(Stop, self.services)
 
         if not with_log_running:
             failed_set = set(failed)

--- a/pgctl/cli.py
+++ b/pgctl/cli.py
@@ -22,6 +22,7 @@ from .dependencies import resolve_start_order
 from .errors import CircularAliases
 from .errors import LockHeld
 from .errors import NoPlayground
+from .errors import NoSuchService
 from .errors import PgctlUserMessage
 from .errors import reraise
 from .errors import Unsupervised
@@ -706,11 +707,16 @@ class PgctlApp:
         print(JSONEncoder(sort_keys=True, indent=4).encode(self.pgconf))
 
     def service_by_name(self, service_name):
-        """Return an instantiated Service, by name."""
+        """Return an instantiated Service, by name.
+
+        Raises NoSuchService if the service directory does not exist.
+        """
         if os.path.isabs(service_name):
             path = Path(service_name)
         else:
             path = self.pgdir.join(service_name, abs=1)
+        if not path.check(dir=True):
+            raise NoSuchService(f"No such service: '{service_name}'")
         return Service(
             path=path,
             scratch_dir=self.pghome.join(path.relto('/'), abs=1),

--- a/pgctl/cli.py
+++ b/pgctl/cli.py
@@ -18,6 +18,8 @@ from .config import Config
 from .configsearch import search_parent_directories
 from .debug import debug
 from .debug import trace
+from .dependencies import resolve_start_order
+from .dependencies import resolve_stop_order
 from .errors import CircularAliases
 from .errors import LockHeld
 from .errors import NoPlayground
@@ -68,6 +70,8 @@ PGCTL_DEFAULTS = frozendict({
     'environment_process_tracing': True,
     # enable embedded log viewer during start/stop?
     'embedded_log_viewer': True,
+    # service dependency ordering: {service_name: [list of services it depends on]}
+    'dependencies': frozendict(),
 })
 CHANNEL = '[pgctl]'
 
@@ -532,10 +536,61 @@ class PgctlApp:
 
         raise PgctlUserMessage(f'Some services failed to {state}: {commafy(failed)}')
 
+    @cached_property
+    def dependency_map(self):
+        deps = self.pgconf.get('dependencies', {})
+        return {k: tuple(v) if isinstance(v, list) else (v,) for k, v in deps.items()}
+
+    def _services_in_start_order(self):
+        return resolve_start_order(self.services, self.dependency_map)
+
+    def _services_in_stop_order(self):
+        return resolve_stop_order(self.services, self.dependency_map)
+
+    def _group_by_dependency_phase(self, ordered_services, reverse=False):
+        """Group services into phases where each phase's services have all
+        dependencies satisfied by prior phases.
+
+        Returns a list of lists of services.
+        """
+        dep_map = self.dependency_map
+        started = set()
+        phases = []
+        remaining = list(ordered_services)
+
+        while remaining:
+            phase = []
+            for service in list(remaining):
+                deps = set(dep_map.get(service.name, ()))
+                service_names_in_scope = {s.name for s in self.services}
+                relevant_deps = deps & service_names_in_scope
+                if relevant_deps <= started:
+                    phase.append(service)
+            if not phase:
+                phase = [remaining[0]]
+            for s in phase:
+                remaining.remove(s)
+                started.add(s.name)
+            phases.append(phase)
+
+        return phases
+
     def start(self):
         """Idempotent start of a service or group of services"""
-        failed = self.__change_state(Start, self.services)
-        return self.__show_failure('start', failed)
+        dep_map = self.dependency_map
+        if dep_map:
+            ordered = self._services_in_start_order()
+            phases = self._group_by_dependency_phase(ordered)
+            all_failed = []
+            for phase in phases:
+                failed = self.__change_state(Start, phase)
+                all_failed.extend(failed)
+                if failed:
+                    break
+            return self.__show_failure('start', all_failed)
+        else:
+            failed = self.__change_state(Start, self.services)
+            return self.__show_failure('start', failed)
 
     def stop(self, with_log_running=False):
         """Idempotent stop of a service or group of services
@@ -545,7 +600,17 @@ class PgctlApp:
         want to leave the logger running (since poll-ready may still be writing
         log messages).
         """
-        failed = self.__change_state(Stop, self.services)
+        dep_map = self.dependency_map
+        if dep_map:
+            ordered = self._services_in_stop_order()
+            phases = self._group_by_dependency_phase(ordered, reverse=True)
+            all_failed = []
+            for phase in phases:
+                phase_failed = self.__change_state(Stop, phase)
+                all_failed.extend(phase_failed)
+            failed = all_failed
+        else:
+            failed = self.__change_state(Stop, self.services)
 
         if not with_log_running:
             failed_set = set(failed)

--- a/pgctl/dependencies.py
+++ b/pgctl/dependencies.py
@@ -27,7 +27,7 @@ def topological_sort(services, dependency_map):
             return
         if state[name] == IN_PROGRESS:
             raise CircularDependencies(
-                "Circular dependency detected involving service '%s'" % name
+                f"Circular dependency detected involving service '{name}'"
             )
         state[name] = IN_PROGRESS
         for neighbor in adj[name]:
@@ -69,11 +69,11 @@ def resolve_start_order(services, dependency_map, service_by_name_fn=None):
                         service_by_name[dep] = service_by_name_fn(dep)
                     except Exception:
                         raise PgctlUserMessage(
-                            "Service '%s' depends on '%s', but '%s' does not exist" % (name, dep, dep)
+                            f"Service '{name}' depends on '{dep}', but '{dep}' does not exist"
                         )
                 else:
                     raise PgctlUserMessage(
-                        "Service '%s' depends on '%s', but '%s' does not exist" % (name, dep, dep)
+                        f"Service '{name}' depends on '{dep}', but '{dep}' does not exist"
                     )
                 needed.add(dep)
                 queue.append(dep)

--- a/pgctl/dependencies.py
+++ b/pgctl/dependencies.py
@@ -1,4 +1,5 @@
 from .errors import CircularDependencies
+from .errors import PgctlUserMessage
 
 
 def topological_sort(services, dependency_map):
@@ -38,14 +39,20 @@ def topological_sort(services, dependency_map):
         visit(name)
 
     order.reverse()
-    return [service_by_name[name] for name in order if name in service_by_name]
+    return [service_by_name[name] for name in order]
 
 
-def resolve_start_order(services, dependency_map):
+def resolve_start_order(services, dependency_map, service_by_name_fn=None):
     """Return services ordered so dependencies start first.
 
     Also includes any transitive dependencies from dependency_map that are
-    not already in the requested services list.
+    not already in the requested services list. If service_by_name_fn is
+    provided, it will be called to resolve dependency names into Service
+    objects. Unknown dependency names raise an error.
+
+    :param services: list of Service objects explicitly requested
+    :param dependency_map: dict mapping service name -> tuple of dependency names
+    :param service_by_name_fn: callable(name) -> Service, for resolving deps not in services
     """
     service_by_name = {s.name: s for s in services}
     needed = set(service_by_name.keys())
@@ -55,15 +62,23 @@ def resolve_start_order(services, dependency_map):
         name = queue.pop()
         for dep in dependency_map.get(name, ()):
             if dep not in needed:
+                if dep in service_by_name:
+                    pass
+                elif service_by_name_fn is not None:
+                    try:
+                        service_by_name[dep] = service_by_name_fn(dep)
+                    except Exception:
+                        raise PgctlUserMessage(
+                            "Service '%s' depends on '%s', but '%s' does not exist" % (name, dep, dep)
+                        )
+                else:
+                    raise PgctlUserMessage(
+                        "Service '%s' depends on '%s', but '%s' does not exist" % (name, dep, dep)
+                    )
                 needed.add(dep)
                 queue.append(dep)
 
     return topological_sort(
-        [service_by_name[n] for n in needed if n in service_by_name],
+        [service_by_name[n] for n in needed],
         dependency_map,
     )
-
-
-def resolve_stop_order(services, dependency_map):
-    """Return services ordered so dependents stop first (reverse of start)."""
-    return list(reversed(resolve_start_order(services, dependency_map)))

--- a/pgctl/dependencies.py
+++ b/pgctl/dependencies.py
@@ -1,0 +1,69 @@
+from .errors import CircularDependencies
+
+
+def topological_sort(services, dependency_map):
+    """Sort services so that dependencies come before dependents.
+
+    :param services: iterable of service objects (must have .name attribute)
+    :param dependency_map: dict mapping service name -> list of service names it depends on
+    :return: list of services in dependency order
+    """
+    service_by_name = {s.name: s for s in services}
+    service_names = set(service_by_name.keys())
+
+    adj = {name: [] for name in service_names}
+    for name in service_names:
+        for dep in dependency_map.get(name, ()):
+            if dep in service_names:
+                adj[dep].append(name)
+
+    UNVISITED, IN_PROGRESS, DONE = 0, 1, 2
+    state = {name: UNVISITED for name in service_names}
+    order = []
+
+    def visit(name):
+        if state[name] == DONE:
+            return
+        if state[name] == IN_PROGRESS:
+            raise CircularDependencies(
+                "Circular dependency detected involving service '%s'" % name
+            )
+        state[name] = IN_PROGRESS
+        for neighbor in adj[name]:
+            visit(neighbor)
+        state[name] = DONE
+        order.append(name)
+
+    for name in sorted(service_names):
+        visit(name)
+
+    order.reverse()
+    return [service_by_name[name] for name in order if name in service_by_name]
+
+
+def resolve_start_order(services, dependency_map):
+    """Return services ordered so dependencies start first.
+
+    Also includes any transitive dependencies from dependency_map that are
+    not already in the requested services list.
+    """
+    service_by_name = {s.name: s for s in services}
+    needed = set(service_by_name.keys())
+
+    queue = list(needed)
+    while queue:
+        name = queue.pop()
+        for dep in dependency_map.get(name, ()):
+            if dep not in needed:
+                needed.add(dep)
+                queue.append(dep)
+
+    return topological_sort(
+        [service_by_name[n] for n in needed if n in service_by_name],
+        dependency_map,
+    )
+
+
+def resolve_stop_order(services, dependency_map):
+    """Return services ordered so dependents stop first (reverse of start)."""
+    return list(reversed(resolve_start_order(services, dependency_map)))

--- a/pgctl/errors.py
+++ b/pgctl/errors.py
@@ -22,6 +22,10 @@ class CircularAliases(PgctlUserMessage):
     """The user has configured their pgctl aliases with a circular definition."""
 
 
+class CircularDependencies(PgctlUserMessage):
+    """The user has configured service dependencies with a cycle."""
+
+
 class NoPlayground(PgctlUserMessage):
     """The pgctl system could find no playground to operate on."""
 

--- a/tests/spec/dependencies.py
+++ b/tests/spec/dependencies.py
@@ -1,9 +1,9 @@
 import pytest
 
 from pgctl.dependencies import resolve_start_order
-from pgctl.dependencies import resolve_stop_order
 from pgctl.dependencies import topological_sort
 from pgctl.errors import CircularDependencies
+from pgctl.errors import PgctlUserMessage
 
 
 class FakeService:
@@ -68,10 +68,31 @@ def it_orders_dependencies_before_dependents_on_start():
     assert names.index('api') < names.index('web')
 
 
-def it_orders_dependents_before_dependencies_on_stop():
-    services = [FakeService('web'), FakeService('api'), FakeService('db')]
-    deps = {'api': ['db'], 'web': ['api']}
-    result = resolve_stop_order(services, deps)
+def it_pulls_in_transitive_dependencies():
+    services = [FakeService('web')]
+    all_services = {'web': FakeService('web'), 'api': FakeService('api'), 'db': FakeService('db')}
+    deps = {'web': ['api'], 'api': ['db']}
+    result = resolve_start_order(services, deps, service_by_name_fn=lambda n: all_services[n])
     names = [s.name for s in result]
-    assert names.index('web') < names.index('api')
-    assert names.index('api') < names.index('db')
+    assert 'db' in names
+    assert 'api' in names
+    assert names.index('db') < names.index('api')
+    assert names.index('api') < names.index('web')
+
+
+def it_raises_on_unknown_dependency():
+    services = [FakeService('api')]
+    deps = {'api': ['nonexistent']}
+
+    def bad_lookup(name):
+        raise KeyError(name)
+
+    with pytest.raises(PgctlUserMessage, match="does not exist"):
+        resolve_start_order(services, deps, service_by_name_fn=bad_lookup)
+
+
+def it_raises_on_unknown_dependency_without_resolver():
+    services = [FakeService('api')]
+    deps = {'api': ['nonexistent']}
+    with pytest.raises(PgctlUserMessage, match="does not exist"):
+        resolve_start_order(services, deps)

--- a/tests/spec/dependencies.py
+++ b/tests/spec/dependencies.py
@@ -20,60 +20,58 @@ class FakeService:
         return hash(self.name)
 
 
-class DescribeTopologicalSort:
-
-    def it_handles_no_dependencies(self):
-        services = [FakeService('a'), FakeService('b'), FakeService('c')]
-        result = topological_sort(services, {})
-        assert set(s.name for s in result) == {'a', 'b', 'c'}
-
-    def it_sorts_a_linear_chain(self):
-        services = [FakeService('db'), FakeService('api'), FakeService('web')]
-        deps = {'api': ['db'], 'web': ['api']}
-        result = topological_sort(services, deps)
-        names = [s.name for s in result]
-        assert names.index('db') < names.index('api')
-        assert names.index('api') < names.index('web')
-
-    def it_sorts_a_diamond_dependency(self):
-        services = [FakeService('db'), FakeService('cache'), FakeService('api'), FakeService('web')]
-        deps = {'api': ['db', 'cache'], 'web': ['api']}
-        result = topological_sort(services, deps)
-        names = [s.name for s in result]
-        assert names.index('db') < names.index('api')
-        assert names.index('cache') < names.index('api')
-        assert names.index('api') < names.index('web')
-
-    def it_raises_on_circular_dependency(self):
-        services = [FakeService('a'), FakeService('b')]
-        deps = {'a': ['b'], 'b': ['a']}
-        with pytest.raises(CircularDependencies):
-            topological_sort(services, deps)
-
-    def it_ignores_dependencies_not_in_service_list(self):
-        services = [FakeService('api')]
-        deps = {'api': ['db']}
-        result = topological_sort(services, deps)
-        assert [s.name for s in result] == ['api']
+def it_handles_no_dependencies():
+    services = [FakeService('a'), FakeService('b'), FakeService('c')]
+    result = topological_sort(services, {})
+    assert set(s.name for s in result) == {'a', 'b', 'c'}
 
 
-class DescribeResolveStartOrder:
-
-    def it_orders_dependencies_before_dependents(self):
-        services = [FakeService('web'), FakeService('api'), FakeService('db')]
-        deps = {'api': ['db'], 'web': ['api']}
-        result = resolve_start_order(services, deps)
-        names = [s.name for s in result]
-        assert names.index('db') < names.index('api')
-        assert names.index('api') < names.index('web')
+def it_sorts_a_linear_chain():
+    services = [FakeService('db'), FakeService('api'), FakeService('web')]
+    deps = {'api': ['db'], 'web': ['api']}
+    result = topological_sort(services, deps)
+    names = [s.name for s in result]
+    assert names.index('db') < names.index('api')
+    assert names.index('api') < names.index('web')
 
 
-class DescribeResolveStopOrder:
+def it_sorts_a_diamond_dependency():
+    services = [FakeService('db'), FakeService('cache'), FakeService('api'), FakeService('web')]
+    deps = {'api': ['db', 'cache'], 'web': ['api']}
+    result = topological_sort(services, deps)
+    names = [s.name for s in result]
+    assert names.index('db') < names.index('api')
+    assert names.index('cache') < names.index('api')
+    assert names.index('api') < names.index('web')
 
-    def it_orders_dependents_before_dependencies(self):
-        services = [FakeService('web'), FakeService('api'), FakeService('db')]
-        deps = {'api': ['db'], 'web': ['api']}
-        result = resolve_stop_order(services, deps)
-        names = [s.name for s in result]
-        assert names.index('web') < names.index('api')
-        assert names.index('api') < names.index('db')
+
+def it_raises_on_circular_dependency():
+    services = [FakeService('a'), FakeService('b')]
+    deps = {'a': ['b'], 'b': ['a']}
+    with pytest.raises(CircularDependencies):
+        topological_sort(services, deps)
+
+
+def it_ignores_dependencies_not_in_service_list():
+    services = [FakeService('api')]
+    deps = {'api': ['db']}
+    result = topological_sort(services, deps)
+    assert [s.name for s in result] == ['api']
+
+
+def it_orders_dependencies_before_dependents_on_start():
+    services = [FakeService('web'), FakeService('api'), FakeService('db')]
+    deps = {'api': ['db'], 'web': ['api']}
+    result = resolve_start_order(services, deps)
+    names = [s.name for s in result]
+    assert names.index('db') < names.index('api')
+    assert names.index('api') < names.index('web')
+
+
+def it_orders_dependents_before_dependencies_on_stop():
+    services = [FakeService('web'), FakeService('api'), FakeService('db')]
+    deps = {'api': ['db'], 'web': ['api']}
+    result = resolve_stop_order(services, deps)
+    names = [s.name for s in result]
+    assert names.index('web') < names.index('api')
+    assert names.index('api') < names.index('db')

--- a/tests/spec/dependencies.py
+++ b/tests/spec/dependencies.py
@@ -96,3 +96,17 @@ def it_raises_on_unknown_dependency_without_resolver():
     deps = {'api': ['nonexistent']}
     with pytest.raises(PgctlUserMessage, match="does not exist"):
         resolve_start_order(services, deps)
+
+
+def it_raises_on_nonexistent_service_dependency():
+    """When a dependency references a service that doesn't exist as a directory
+    in the playground, the resolver should raise a clear error message."""
+    services = [FakeService('api')]
+    deps = {'api': ['cache']}
+
+    def resolver_that_checks_path(name):
+        # Simulate what service_by_name does: raise when the path doesn't exist
+        raise KeyError(f"No such service: '{name}'")
+
+    with pytest.raises(PgctlUserMessage, match=r"Service 'api' depends on 'cache', but 'cache' does not exist"):
+        resolve_start_order(services, deps, service_by_name_fn=resolver_that_checks_path)

--- a/tests/spec/dependencies.py
+++ b/tests/spec/dependencies.py
@@ -20,14 +20,14 @@ class FakeService:
         return hash(self.name)
 
 
-class TestTopologicalSort:
+class DescribeTopologicalSort:
 
-    def test_no_dependencies(self):
+    def it_handles_no_dependencies(self):
         services = [FakeService('a'), FakeService('b'), FakeService('c')]
         result = topological_sort(services, {})
         assert set(s.name for s in result) == {'a', 'b', 'c'}
 
-    def test_linear_chain(self):
+    def it_sorts_a_linear_chain(self):
         services = [FakeService('db'), FakeService('api'), FakeService('web')]
         deps = {'api': ['db'], 'web': ['api']}
         result = topological_sort(services, deps)
@@ -35,7 +35,7 @@ class TestTopologicalSort:
         assert names.index('db') < names.index('api')
         assert names.index('api') < names.index('web')
 
-    def test_diamond_dependency(self):
+    def it_sorts_a_diamond_dependency(self):
         services = [FakeService('db'), FakeService('cache'), FakeService('api'), FakeService('web')]
         deps = {'api': ['db', 'cache'], 'web': ['api']}
         result = topological_sort(services, deps)
@@ -44,22 +44,22 @@ class TestTopologicalSort:
         assert names.index('cache') < names.index('api')
         assert names.index('api') < names.index('web')
 
-    def test_circular_dependency_raises(self):
+    def it_raises_on_circular_dependency(self):
         services = [FakeService('a'), FakeService('b')]
         deps = {'a': ['b'], 'b': ['a']}
         with pytest.raises(CircularDependencies):
             topological_sort(services, deps)
 
-    def test_dependency_not_in_service_list_is_ignored(self):
+    def it_ignores_dependencies_not_in_service_list(self):
         services = [FakeService('api')]
         deps = {'api': ['db']}
         result = topological_sort(services, deps)
         assert [s.name for s in result] == ['api']
 
 
-class TestResolveStartOrder:
+class DescribeResolveStartOrder:
 
-    def test_simple(self):
+    def it_orders_dependencies_before_dependents(self):
         services = [FakeService('web'), FakeService('api'), FakeService('db')]
         deps = {'api': ['db'], 'web': ['api']}
         result = resolve_start_order(services, deps)
@@ -68,9 +68,9 @@ class TestResolveStartOrder:
         assert names.index('api') < names.index('web')
 
 
-class TestResolveStopOrder:
+class DescribeResolveStopOrder:
 
-    def test_reverse_of_start(self):
+    def it_orders_dependents_before_dependencies(self):
         services = [FakeService('web'), FakeService('api'), FakeService('db')]
         deps = {'api': ['db'], 'web': ['api']}
         result = resolve_stop_order(services, deps)

--- a/tests/unit/dependencies_test.py
+++ b/tests/unit/dependencies_test.py
@@ -1,0 +1,79 @@
+import pytest
+
+from pgctl.dependencies import resolve_start_order
+from pgctl.dependencies import resolve_stop_order
+from pgctl.dependencies import topological_sort
+from pgctl.errors import CircularDependencies
+
+
+class FakeService:
+    def __init__(self, name):
+        self.name = name
+
+    def __repr__(self):
+        return f'FakeService({self.name!r})'
+
+    def __eq__(self, other):
+        return self.name == other.name
+
+    def __hash__(self):
+        return hash(self.name)
+
+
+class TestTopologicalSort:
+
+    def test_no_dependencies(self):
+        services = [FakeService('a'), FakeService('b'), FakeService('c')]
+        result = topological_sort(services, {})
+        assert set(s.name for s in result) == {'a', 'b', 'c'}
+
+    def test_linear_chain(self):
+        services = [FakeService('db'), FakeService('api'), FakeService('web')]
+        deps = {'api': ['db'], 'web': ['api']}
+        result = topological_sort(services, deps)
+        names = [s.name for s in result]
+        assert names.index('db') < names.index('api')
+        assert names.index('api') < names.index('web')
+
+    def test_diamond_dependency(self):
+        services = [FakeService('db'), FakeService('cache'), FakeService('api'), FakeService('web')]
+        deps = {'api': ['db', 'cache'], 'web': ['api']}
+        result = topological_sort(services, deps)
+        names = [s.name for s in result]
+        assert names.index('db') < names.index('api')
+        assert names.index('cache') < names.index('api')
+        assert names.index('api') < names.index('web')
+
+    def test_circular_dependency_raises(self):
+        services = [FakeService('a'), FakeService('b')]
+        deps = {'a': ['b'], 'b': ['a']}
+        with pytest.raises(CircularDependencies):
+            topological_sort(services, deps)
+
+    def test_dependency_not_in_service_list_is_ignored(self):
+        services = [FakeService('api')]
+        deps = {'api': ['db']}
+        result = topological_sort(services, deps)
+        assert [s.name for s in result] == ['api']
+
+
+class TestResolveStartOrder:
+
+    def test_simple(self):
+        services = [FakeService('web'), FakeService('api'), FakeService('db')]
+        deps = {'api': ['db'], 'web': ['api']}
+        result = resolve_start_order(services, deps)
+        names = [s.name for s in result]
+        assert names.index('db') < names.index('api')
+        assert names.index('api') < names.index('web')
+
+
+class TestResolveStopOrder:
+
+    def test_reverse_of_start(self):
+        services = [FakeService('web'), FakeService('api'), FakeService('db')]
+        deps = {'api': ['db'], 'web': ['api']}
+        result = resolve_stop_order(services, deps)
+        names = [s.name for s in result]
+        assert names.index('web') < names.index('api')
+        assert names.index('api') < names.index('db')


### PR DESCRIPTION
## Service dependency ordering for `pgctl start`

Adds a `dependencies` key to `pgctl.yaml` that declares startup ordering between services. Dependencies start (and become ready) before their dependents. Services within the same dependency tier start in parallel.

```yaml
dependencies:
  api:
    - db
    - cache
  web:
    - api
```

**Behavior:**
- Topological sort resolves start order; circular deps are detected and error cleanly
- Transitive deps are pulled in automatically (`pgctl start web` also starts `api`, `db`, `cache`)
- If a dependency fails to start, its dependents are never attempted
- No dependencies configured = original parallel-start behavior (fully backwards compatible)

**Integration testing performed:**

Set up a playground with 4 fake services (`db`, `cache`, `api`, `web`) with varying startup latencies and readiness checks.